### PR TITLE
Handle Kitura-redis and Kitura-Session-Redis on all Swift drivers

### DIFF
--- a/Kitura-Session-Redis/common/before_tests.sh
+++ b/Kitura-Session-Redis/common/before_tests.sh
@@ -19,8 +19,13 @@
 # If any commands fail, we want the shell script to exit immediately.
 set -e
 
+testDirectory="${projectFolder}/Tests/KituraSessionRedis"
+if [ ! -d "${testDirectory}" ]; then
+  testDirectory="${projectFolder}/Tests/KituraSessionRedisTests"
+fi
+
 # Set authentication password for redis server
-password=$(head -n 1 "${projectFolder}/Tests/KituraSessionRedis/password.txt")
+password=$(head -n 1 "${testDirectory}/password.txt")
 echo ">> redis password: $password"
 
 # Update redis password

--- a/Kitura-redis/common/before_tests.sh
+++ b/Kitura-redis/common/before_tests.sh
@@ -19,8 +19,13 @@
 # If any commands fail, we want the shell script to exit immediately.
 set -e
 
+testDirectory="${projectFolder}/Tests/SwiftRedis"
+if [ ! -d "${testDirectory}" ]; then
+  testDirectory="${projectFolder}/Tests/SwiftRedisTests"
+fi
+
 # Set authentication password for redis server
-password=$(head -n 1 "${projectFolder}/Tests/SwiftRedis/password.txt")
+password=$(head -n 1 "${testDirectory}/password.txt")
 echo ">> redis password: $password"
 
 # Update redis password


### PR DESCRIPTION
As test module names differ based on Swift driver, due to the required Tests suffix in the module name as of Swift 08/07, the code that finds the Redis password in the Package Builder scripts is sometimes broken.

The changes here simply assume that the test module is without the Tests suffix at first. It then tests to make sure that the directory based on that module name exists. If it doesn't, a test directory name is created with the Tests suffix.

I tested this locally on macOS, with an added exit statement in it, after the script echos the password.
