### PR TITLE
Adding swiftlint.yml file to enforce code conventions

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,11 @@
+included:
+    - Sources
+    - Tests
+custom_rules:
+  double_space:
+    include: "*.swift"
+    name: "Double space" 
+    regex: "([a-z,A-Z] \s+)" 
+    message: "Double space between keywords" 
+    match_kinds: keyword 
+    severity: warning 


### PR DESCRIPTION
In the compiler, you will get warnings or errors according to the ruleset inside the `swiftlint.yml` file and swiftlint itself
