### PR TITLE
Make 'build' target equal 'buildDebug' 

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -34,14 +34,14 @@ endif
 all: buildDebug
 
 buildDebug:
-	make SWIFT_BUILD_CONFIGURATION="debug" SWIFTC_FLAGS="-Xswiftc -DDEBUG" buildInternal
+	make SWIFT_BUILD_CONFIGURATION="debug" SWIFTC_FLAGS="-Xswiftc -DDEBUG" _build
 
 buildRelease:
-	make SWIFT_BUILD_CONFIGURATION="release" buildInternal
+	make SWIFT_BUILD_CONFIGURATION="release" _build
 
 build: buildDebug
 
-buildInternal: custombuild
+_build: custombuild
 	@echo --- Running build on $(UNAME)
 	@echo --- Build scripts directory: ${KITURA_CI_BUILD_SCRIPTS_DIR}
 	@echo --- Checking swift version

--- a/build/Makefile
+++ b/build/Makefile
@@ -34,12 +34,14 @@ endif
 all: buildDebug
 
 buildDebug:
-	make SWIFT_BUILD_CONFIGURATION="debug" SWIFTC_FLAGS="-Xswiftc -DDEBUG" build
+	make SWIFT_BUILD_CONFIGURATION="debug" SWIFTC_FLAGS="-Xswiftc -DDEBUG" buildInternal
 
 buildRelease:
-	make SWIFT_BUILD_CONFIGURATION="release" build
+	make SWIFT_BUILD_CONFIGURATION="release" buildInternal
 
-build: custombuild
+build: buildDebug
+
+buildInternal: custombuild
 	@echo --- Running build on $(UNAME)
 	@echo --- Build scripts directory: ${KITURA_CI_BUILD_SCRIPTS_DIR}
 	@echo --- Checking swift version


### PR DESCRIPTION
It is needed since other targets like `test` depend on `build`. So renamed `build` to `_build` to be used internally in the Makefile, and added new `build` target equal to `buildDebug` 
