### PR TITLE
Enable Continuous Integration using the Swift 3 Release builds

### DIFF
--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -41,22 +41,30 @@ sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100
 
 WORK_DIR=$1
 
-THRESHOLD_DATE="20160801"
-THRESHOLD_0807="20160807"
-THRESHOLD_0818="20160818"
-THRESHOLD_0823="20160823"
-DATE=`echo ${SWIFT_SNAPSHOT} | awk -F- '{print $4$5$6}'`
-
-echo "Threshold date =$THRESHOLD_DATE"
-echo "Date=$DATE"
-
-if [ $DATE -ge $THRESHOLD_DATE ]; then
-	echo "Setting branch for libdispatch to master"
-	export LIBDISPATCH_BRANCH="master"
+if [[ ${SWIFT_SNAPSHOT} =~ ^.*RELEASE.*$ ]]; then
+	SNAPSHOT_TYPE=$(echo "$SWIFT_SNAPSHOT" | tr '[:upper:]' '[:lower:]')
 else
-	echo "Setting branch for libdispatch to experimental/foundation"
-	export LIBDISPATCH_BRANCH="experimental/foundation"
-	export CFLAGS="-fuse-ld=gold"
+	SNAPSHOT_TYPE=development
+fi
+
+if [ $SNAPSHOT_TYPE == "development" ]; then
+	THRESHOLD_DATE="20160801"
+	THRESHOLD_0807="20160807"
+	THRESHOLD_0818="20160818"
+	THRESHOLD_0823="20160823"
+	DATE=`echo ${SWIFT_SNAPSHOT} | awk -F- '{print $4$5$6}'`
+
+	echo "Threshold date =$THRESHOLD_DATE"
+	echo "Date=$DATE"
+
+	if [ $DATE -ge $THRESHOLD_DATE ]; then
+		echo "Setting branch for libdispatch to master"
+		export LIBDISPATCH_BRANCH="master"
+	else
+		echo "Setting branch for libdispatch to experimental/foundation"
+		export LIBDISPATCH_BRANCH="experimental/foundation"
+		export CFLAGS="-fuse-ld=gold"
+	fi
 fi
 
 # Environment vars
@@ -67,36 +75,39 @@ export UBUNTU_VERSION_NO_DOTS=`echo $version | awk -F. '{print $1$2}'`
 echo ">> Installing '${SWIFT_SNAPSHOT}'..."
 # Install Swift compiler
 cd $WORK_DIR
-wget https://swift.org/builds/development/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz
+wget https://swift.org/builds/$SNAPSHOT_TYPE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz
 tar xzvf $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz
 export PATH=$WORK_DIR/$SWIFT_SNAPSHOT-$UBUNTU_VERSION/usr/bin:$PATH
 swiftc -h
-# Clone and install swift-corelibs-libdispatch
-echo ">> Installing swift-corelibs-libdispatch..."
-if [ $DATE -eq $THRESHOLD_0807 ]; then
-	echo "Get the 55261225184e49c6a42c38bbedb144c2610def4a commit"
-	git clone -n https://github.com/apple/swift-corelibs-libdispatch.git
-	cd swift-corelibs-libdispatch
-	git checkout 55261225184e49c6a42c38bbedb144c2610def4a
-	cd ..
-elif [ $DATE -eq $THRESHOLD_0818 ]; then
-	echo "Get the 1a7ff3f3e1073eb3352a56ab121ccfa712c42cef commit"
-	git clone -n https://github.com/apple/swift-corelibs-libdispatch.git
-	cd swift-corelibs-libdispatch
-	git checkout 1a7ff3f3e1073eb3352a56ab121ccfa712c42cef
-	cd ..
-elif [ $DATE -ge $THRESHOLD_0823 ]; then
-	echo "No need to get libdispatch.  It is part of the swift vesions starting with 08-23"
-else
-	echo "Get the ${LIBDISPATCH_BRANCH} branch"
-	git clone -b ${LIBDISPATCH_BRANCH}  https://github.com/apple/swift-corelibs-libdispatch.git
-fi
 
-if [ $DATE -lt $THRESHOLD_0823 ]; then
-	echo "Compiling libdispatch"
-	cd swift-corelibs-libdispatch && git submodule init && git submodule update && sh ./autogen.sh && ./configure --with-swift-toolchain=$WORK_DIR/$SWIFT_SNAPSHOT-$UBUNTU_VERSION/usr --prefix=$WORK_DIR/$SWIFT_SNAPSHOT-$UBUNTU_VERSION/usr && make
-	make install
-	echo "Finished building libdispatch"
-	# Return to previous directory
-	cd -
+if [ $SNAPSHOT_TYPE == "development" ]; then
+	# Clone and install swift-corelibs-libdispatch
+	echo ">> Installing swift-corelibs-libdispatch..."
+	if [ $DATE -eq $THRESHOLD_0807 ]; then
+		echo "Get the 55261225184e49c6a42c38bbedb144c2610def4a commit"
+		git clone -n https://github.com/apple/swift-corelibs-libdispatch.git
+		cd swift-corelibs-libdispatch
+		git checkout 55261225184e49c6a42c38bbedb144c2610def4a
+		cd ..
+	elif [ $DATE -eq $THRESHOLD_0818 ]; then
+		echo "Get the 1a7ff3f3e1073eb3352a56ab121ccfa712c42cef commit"
+		git clone -n https://github.com/apple/swift-corelibs-libdispatch.git
+		cd swift-corelibs-libdispatch
+		git checkout 1a7ff3f3e1073eb3352a56ab121ccfa712c42cef
+		cd ..
+	elif [ $DATE -ge $THRESHOLD_0823 ]; then
+		echo "No need to get libdispatch.  It is part of the swift vesions starting with 08-23"
+	else
+		echo "Get the ${LIBDISPATCH_BRANCH} branch"
+		git clone -b ${LIBDISPATCH_BRANCH}  https://github.com/apple/swift-corelibs-libdispatch.git
+	fi
+
+	if [ $DATE -lt $THRESHOLD_0823 ]; then
+		echo "Compiling libdispatch"
+		cd swift-corelibs-libdispatch && git submodule init && git submodule update && sh ./autogen.sh && ./configure --with-swift-toolchain=$WORK_DIR/$SWIFT_SNAPSHOT-$UBUNTU_VERSION/usr --prefix=$WORK_DIR/$SWIFT_SNAPSHOT-$UBUNTU_VERSION/usr && make
+		make install
+		echo "Finished building libdispatch"
+		# Return to previous directory
+		cd -
+	fi
 fi

--- a/osx/install_swift_binaries.sh
+++ b/osx/install_swift_binaries.sh
@@ -31,8 +31,14 @@ brew install git
 brew install curl
 brew install wget || brew outdated wget || brew upgrade wget
 
+if [[ ${SWIFT_SNAPSHOT} =~ ^.*RELEASE.*$ ]]; then
+	SNAPSHOT_TYPE=$(echo "$SWIFT_SNAPSHOT" | tr '[:upper:]' '[:lower:]')
+else
+	SNAPSHOT_TYPE=development
+fi
+
 # Install Swift binaries
 # See http://apple.stackexchange.com/questions/72226/installing-pkg-with-terminal
-wget https://swift.org/builds/development/xcode/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-osx.pkg
+wget https://swift.org/builds/$SNAPSHOT_TYPE/xcode/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-osx.pkg
 sudo installer -pkg $SWIFT_SNAPSHOT-osx.pkg -target /
 export PATH=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin:"${PATH}"


### PR DESCRIPTION
Changed the two platform specific shell scripts that install the Swift binaries in order to be able to install the Swift 3 GA (Release) binaries.

This was tested by:
1. Creating a branch of Kitura-Credentials in which the following changes were made:
   1. .swift-version was updated to 3.0-RELEASE
   2. The Repository for Package-Builder in the .gitmodules file was changed to https://github.com/shmuelk/Package-Builder.git
2. A PR was created against Kitura-Credentials and travis-ci automatically ran to completion.

The created test PR is: https://github.com/IBM-Swift/Kitura-Credentials/pull/24
The Travis-CI build is: https://travis-ci.org/IBM-Swift/Kitura-Credentials/builds/159859813
