### PR TITLE
Add support for proper .swift-version files for Swift 3 GA when using swiftenv.

### DIFF
--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -43,8 +43,11 @@ WORK_DIR=$1
 
 if [[ ${SWIFT_SNAPSHOT} =~ ^.*RELEASE.*$ ]]; then
 	SNAPSHOT_TYPE=$(echo "$SWIFT_SNAPSHOT" | tr '[:upper:]' '[:lower:]')
-else
+elif [[ ${SWIFT_SNAPSHOT} =~ ^.*DEVELOPMENT.*$ ]]; then
 	SNAPSHOT_TYPE=development
+else
+	SNAPSHOT_TYPE="$(echo "$SWIFT_SNAPSHOT" | tr '[:upper:]' '[:lower:]')-release"
+        SWIFT_SNAPSHOT="${SWIFT_SNAPSHOT}-RELEASE"
 fi
 
 if [ $SNAPSHOT_TYPE == "development" ]; then

--- a/osx/install_swift_binaries.sh
+++ b/osx/install_swift_binaries.sh
@@ -33,8 +33,11 @@ brew install wget || brew outdated wget || brew upgrade wget
 
 if [[ ${SWIFT_SNAPSHOT} =~ ^.*RELEASE.*$ ]]; then
 	SNAPSHOT_TYPE=$(echo "$SWIFT_SNAPSHOT" | tr '[:upper:]' '[:lower:]')
-else
+elif [[ ${SWIFT_SNAPSHOT} =~ ^.*DEVELOPMENT.*$ ]]; then
 	SNAPSHOT_TYPE=development
+else
+	SNAPSHOT_TYPE="$(echo "$SWIFT_SNAPSHOT" | tr '[:upper:]' '[:lower:]')-release"
+        SWIFT_SNAPSHOT="${SWIFT_SNAPSHOT}-RELEASE"
 fi
 
 # Install Swift binaries


### PR DESCRIPTION
Added support for a simple release number in the .swift-version file which is suported by swiftenv

It turns out that swiftenv wants 3.0 in the .swift-version file and not 3.0-RELEASE.

This was tested by:
1.  Creating a branch of Kitura-Credentials in which the following changes were made:
   1.   .swift-version was updated to 3.0-RELEASE
   2.  The Repository for Package-Builder in the .gitmodules file was changed to https://github.com/shmuelk/Package-Builder.git
2.   A PR was created against Kitura-Credentials and travis-ci automatically ran to completion.

The created test PR is: IBM-Swift/Kitura-Credentials#25
The Travis-CI build is: https://travis-ci.org/IBM-Swift/Kitura-Credentials/jobs/159921536
