### PR TITLE
Removing some libraries since libdispatch is included in swift GA now.

### DIFF
--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -30,7 +30,7 @@ set -e
 set -o verbose
 
 sudo apt-get update
-sudo apt-get -y install clang-3.8 lldb-3.8 libicu-dev libkqueue-dev libtool libcurl4-openssl-dev libbsd-dev libblocksruntime-dev build-essential libssl-dev uuid-dev
+sudo apt-get -y install clang-3.8 lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev
 
 # Remove default version of clang from PATH
 export PATH=`echo ${PATH} | awk -v RS=: -v ORS=: '/clang/ {next} {print}'`


### PR DESCRIPTION
Tested this on Kitura-net and it passed.

https://travis-ci.org/BDHernand/Kitura-net/builds/164700633
