### PR TITLE
IBM-Swift/Kitura#137: Add codecov integration for travis cron builds

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -125,3 +125,6 @@ sourceScript "${projectFolder}/Package-Builder/${projectName}/common/after_tests
 
 # Execute OS specific post-test steps
 sourceScript "${projectFolder}/Package-Builder/${projectName}/${osName}/after_tests.sh" ">> Completed ${osName} post-tests steps."
+
+# Generate test code coverage report
+sourceScript "${projectFolder}/Package-Builder/codecov.sh"

--- a/codecov.sh
+++ b/codecov.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+if [[ $TRAVIS && $TRAVIS_EVENT_TYPE != "cron" ]]; then
+    echo "Not cron build. Skipping code coverage generation"
+    exit 0
+fi
+
+if [[ $TRAVIS && $TRAVIS_OS_NAME != "osx" ]]; then
+    echo "Not osx build. Skipping code coverage generation"
+    exit 0
+fi
+
+echo "Starting code coverage generation"
+uname -a
+
+SDK=macosx
+xcodebuild -version
+xcodebuild -version -sdk $SDK
+if [[ $? != 0 ]]; then
+    exit 1
+fi
+
+PROJ_CMD="swift package generate-xcodeproj"
+echo "Running $PROJ_CMD"
+PROJ_OUTPUT=$(eval "$PROJ_CMD")
+PROJ_EXIT_CODE=$?
+echo "$PROJ_OUTPUT"
+if [[ $PROJ_EXIT_CODE != 0 ]]; then
+    exit 1
+fi
+
+PROJECT="${PROJ_OUTPUT##*/}"
+SCHEME="${PROJECT%.xcodeproj}"
+
+TEST_CMD="xcodebuild -project $PROJECT -scheme $SCHEME -sdk $SDK -enableCodeCoverage YES test"
+echo "Running $TEST_CMD"
+eval "$TEST_CMD"
+if [[ $? != 0 ]]; then
+    exit 1
+fi
+
+bash <(curl -s https://codecov.io/bash) -J "^${SCHEME}\$"
+if [[ $? != 0 ]]; then
+    echo "Error running codecov.io bash script"
+    exit 1
+fi
+
+echo "Successfully generated codecov.io report"


### PR DESCRIPTION
Test code coverage integration in build-package.sh. This code coverage generation will only be done for osx builds as xcodebuild which is used here is not available on linux.

Also, the script only does it's work on travis "cron" builds, it doesn't generate this coverage on every build. To enable a cron build for a repo, on that repo's page on travis, go to "More options -> Settings -> Cron Jobs" and add a cron build for the branch you want code coverage data for. Cron job support for a repo will need to be requested if it is not available (https://docs.travis-ci.com/user/cron-jobs/)

No additional changes are needed to enable this for a repo. However, various aspects can be customized by adding a .codecov.yml file for the repo (https://github.com/codecov/support/wiki/Codecov-Yaml). See Kitura for an example.

Also a badge can be added showing the code coverage for a repository by adding a line to it's README. An example for Kitura:

```
"[![Code Coverage](https://codecov.io/gh/IBM-Swift/Kitura/branch/master/graph/badge.svg)](https://codecov.io/gh/IBM-Swift/Kitura)"
```

Travis build logs for Kitura with these changes:
1. Code coverage skipped as not cron - https://travis-ci.org/IBM-Swift/Kitura/builds/166461359
2. Code coverage skipped as not osx - https://travis-ci.org/IBM-Swift/Kitura/jobs/166470277
3. Code coverage generated for a cron osx build - https://travis-ci.org/IBM-Swift/Kitura/jobs/166470279
