### PR TITLE
Remove @@HOMEBREW_PREFIX@@ in the redis.conf file

### DIFF
--- a/Kitura-redis/osx/before_tests.sh
+++ b/Kitura-redis/osx/before_tests.sh
@@ -24,3 +24,6 @@ brew install redis || brew outdated redis || brew upgrade redis
 
 # Set environment variable that points to conf file
 export REDIS_CONF_FILE=/usr/local/etc/redis.conf
+
+# Update Redis conf file to point to the correct directory for the database
+sudo perl -pi -e "s/@@HOMEBREW_PREFIX@@/\\/usr\\/local/g" $REDIS_CONF_FILE


### PR DESCRIPTION
In the recent past a change occurred to the Redis installed via Homebrew in the osx builds. It had in it in various places the text @@HOMEBREW_PREFIX@@. This caused a problem starting the Redis server due to that text being in the configuration of the directory that is suppose to hold the database, if written out. Apparently Redis does a CD to that directory which failed.

This change does an edit of the redis.conf file, on osx only, changing all occurrences of @@HOMEBREW_PREFIX@@ to /usr/local.

The failure can be seen in the build https://travis-ci.org/IBM-Swift/Kitura-redis/jobs/170270979

This was tested by creating a branch of Kitura-redis called issue_fix_build and changing the submodule definition for Package-Builder to point to my fork. When this was pushed a build ran and here are the results https://travis-ci.org/IBM-Swift/Kitura-redis/jobs/170418351
