### PR TITLE
Generate code coverage for builds targeting master branch

### DIFF
--- a/codecov.sh
+++ b/codecov.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
-if [[ $TRAVIS && $TRAVIS_EVENT_TYPE != "cron" ]]; then
-    echo "Not cron build. Skipping code coverage generation"
+if [[ $TRAVIS && $TRAVIS_BRANCH != "master" && $TRAVIS_EVENT_TYPE != "cron" ]]; then
+    echo "Not master or cron build. Skipping code coverage generation"
     exit 0
 fi
 


### PR DESCRIPTION
Generate code coverage for builds targeting master branch so we are able to track code coverage more easily.