### PR TITLE
adding pre-release snapshot support

### DIFF
--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -41,6 +41,8 @@ sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100
 
 if [[ ${SWIFT_SNAPSHOT} =~ ^.*RELEASE.*$ ]]; then
 	SNAPSHOT_TYPE=$(echo "$SWIFT_SNAPSHOT" | tr '[:upper:]' '[:lower:]')
+elif [[ ${SWIFT_SNAPSHOT} =~ ^swift-.*-DEVELOPMENT.*$ ]]; then
+    SNAPSHOT_TYPE=${SWIFT_SNAPSHOT%-DEVELOPMENT*}-branch
 elif [[ ${SWIFT_SNAPSHOT} =~ ^.*DEVELOPMENT.*$ ]]; then
 	SNAPSHOT_TYPE=development
 else

--- a/osx/install_swift_binaries.sh
+++ b/osx/install_swift_binaries.sh
@@ -33,6 +33,8 @@ brew install wget || brew outdated wget || brew upgrade wget
 
 if [[ ${SWIFT_SNAPSHOT} =~ ^.*RELEASE.*$ ]]; then
 	SNAPSHOT_TYPE=$(echo "$SWIFT_SNAPSHOT" | tr '[:upper:]' '[:lower:]')
+elif [[ ${SWIFT_SNAPSHOT} =~ ^swift-.*-DEVELOPMENT.*$ ]]; then
+    SNAPSHOT_TYPE=${SWIFT_SNAPSHOT%-DEVELOPMENT*}-branch
 elif [[ ${SWIFT_SNAPSHOT} =~ ^.*DEVELOPMENT.*$ ]]; then
 	SNAPSHOT_TYPE=development
 else


### PR DESCRIPTION
These changes will allow snapshots with names like "swift-1.3-DEVELOPMENT-SNA..." to yield "swift-1.3-branch" as the `SNAPSHOT_TYPE` instead of "development" by identifying names containing "swift-.*-DEVELOPMENT.*"
Part of:
https://github.com/IBM-Swift/Swift-cfenv/issues/51
