### PR TITLE
Revert "Develop"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ script:
 
 If you need to install system-level dependencies such as libmysqlclient-dev, you can do so in the `before_install` section of the `.travis.yml` file so that the Travis CI build environment is ready for compilation and testing of your Swift package.
 
-### How to start the build-package.sh script
-This script must be started form the folder that contains your Swift package. Also, please note that the `projectDir` argument passed to the script should be the directory of the whole repository. For most projects, this is the same as the folder that contains your Swift package, as shown in the example above. However, there are repositories where the Swift packaage is a sub-folder in the main project.
-
 ### Providing custom credentials
 It is not uncommon for swift packages to need to connect to secure services, offerings, and middleware such as databases.  To do this, credentials are needed from properties files.  To ensure the security of these credentials, many teams use private repositories to store these credentials while their public ones contain dummy files like the one below:
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -57,23 +57,9 @@ function sourceScript () {
   fi
 }
 
-# Determine platform/OS
-echo ">> uname: $(uname)"
-if [ "$(uname)" == "Darwin" ]; then
-  osName="osx"
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-  osName="linux"
-else
-  echo ">> Unsupported platform!"
-  exit 1
-fi
-echo ">> osName: $osName"
-
 # Install swift binaries based on OS
 cd "$(dirname "$0")"/..
 export projectFolder=`pwd`
-projectName="$(basename $projectFolder)"
-echo ">> projectName: $projectName"
 source ./Package-Builder/install-swift.sh
 
 # Show path
@@ -87,12 +73,12 @@ echo ">> Building swift package..."
 
 cd ${projectFolder}
 
-if [ -e ${projectFolder}/.swift-build-macOS ] && [ "${osName}" == "osx" ]; then
-  echo Running custom macOS build command: `cat ${projectFolder}/.swift-build-macOS`
-  source ${projectFolder}/.swift-build-macOS
-elif [ -e ${projectFolder}/.swift-build-linux ] && [ "${osName}" == "linux" ]; then
-  echo Running custom Linux build command: `cat ${projectFolder}/.swift-build-linux`
-  source ${projectFolder}/.swift-build-linux
+if [ -e ${TRAVIS_BUILD_DIR}/.swift-build-macOS ] && [ "${osName}" == "osx" ]; then
+  echo Running custom macOS build command: `cat ${TRAVIS_BUILD_DIR}/.swift-build-macOS`
+  source ${TRAVIS_BUILD_DIR}/.swift-build-macOS
+elif [ -e ${TRAVIS_BUILD_DIR}/.swift-build-linux ] && [ "${osName}" == "linux" ]; then
+  echo Running custom Linux build command: `cat ${TRAVIS_BUILD_DIR}/.swift-build-linux`
+  source ${TRAVIS_BUILD_DIR}/.swift-build-linux
 else
   swift build
 fi

--- a/codecov.sh
+++ b/codecov.sh
@@ -1,16 +1,16 @@
 #! /bin/bash
 
-if [[ $TRAVIS_BRANCH != "master" && $TRAVIS_EVENT_TYPE != "cron" ]]; then
-    echo "Not master or cron build. Skipping code coverage generation."
+if [[ $TRAVIS && $TRAVIS_BRANCH != "master" && $TRAVIS_EVENT_TYPE != "cron" ]]; then
+    echo "Not master or cron build. Skipping code coverage generation"
     exit 0
 fi
 
-if [[ ${osName} != "osx" ]]; then
-    echo "Not osx build. Skipping code coverage generation."
+if [[ $TRAVIS && $TRAVIS_OS_NAME != "osx" ]]; then
+    echo "Not osx build. Skipping code coverage generation"
     exit 0
 fi
 
-echo "Starting code coverage generation..."
+echo "Starting code coverage generation"
 uname -a
 
 SDK=macosx
@@ -21,7 +21,7 @@ if [[ $? != 0 ]]; then
 fi
 
 
-CUSTOM_FILE="${projectFolder}/.swift-xcodeproj"
+CUSTOM_FILE="${TRAVIS_BUILD_DIR}/.swift-xcodeproj"
 
 if [[ -f "$CUSTOM_FILE" ]]; then
   echo Running custom "$osName" xcodeproj command: $(cat "$CUSTOM_FILE")

--- a/install-swift.sh
+++ b/install-swift.sh
@@ -23,6 +23,25 @@
 # If any commands fail, we want the shell script to exit immediately.
 set -e
 
+# Determine platform/OS
+echo ">> uname: $(uname)"
+if [ "$(uname)" == "Darwin" ]; then
+  osName="osx"
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  osName="linux"
+else
+  echo ">> Unsupported platform!"
+  exit 1
+fi
+echo ">> osName: $osName"
+
+# Make the working directory the parent folder of this script
+# Get project name from project folder
+
+projectName="$(basename $projectFolder)"
+echo ">> projectName: $projectName"
+echo
+
 # Swift version for build
 if [ -f "$projectFolder/.swift-version" ]; then
   string="$(cat $projectFolder/.swift-version)";

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,12 +2,12 @@
 
 set +e                   # do not exit immediately temporarily so we can generate a backtrace for any crash
 ulimit -c unlimited      # enable core file generation
-if [ -e ${projectFolder}/.swift-test-macOS ] && [ "$osName" == "osx" ]; then
-  echo Running custom macOS test command: `cat ${projectFolder}/.swift-test-macOS`
-  source ${projectFolder}/.swift-test-macOS
-elif [ -e ${projectFolder}/.swift-test-linux ] && [ "$osName" == "linux" ]; then
-  echo Running custom Linux test command: `cat ${projectFolder}/.swift-test-linux`
-  source ${projectFolder}/.swift-test-linux
+if [ -e ${TRAVIS_BUILD_DIR}/.swift-test-macOS ] && [ "$osName" == "osx" ]; then
+  echo Running custom macOS test command: `cat ${TRAVIS_BUILD_DIR}/.swift-test-macOS`
+  source ${TRAVIS_BUILD_DIR}/.swift-test-macOS
+elif [ -e ${TRAVIS_BUILD_DIR}/.swift-test-linux ] && [ "$osName" == "linux" ]; then
+  echo Running custom Linux test command: `cat ${TRAVIS_BUILD_DIR}/.swift-test-linux`
+  source ${TRAVIS_BUILD_DIR}/.swift-test-linux
 else
   swift test
 fi


### PR DESCRIPTION
Reverts IBM-Swift/Package-Builder#92

@rolivieri - some projects such as [generator-swiftserver](https://github.com/IBM-Swift/generator-swiftserver/blob/master/.travis.yml) use only the `install-swift.sh` file - abstracting the `osName` and `projectFolder` definition breaks projects leveraging this use case.

I am reverting because of unknown impact.