### PR TITLE
Reconcile Package-Builder with Bluemix DevOps Pipeline

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -145,3 +145,11 @@ fi
 
 # Generate test code coverage report
 sourceScript "${projectFolder}/Package-Builder/codecov.sh"
+
+# Clean up build artifacts
+ls -la
+rm -rf ${projectFolder}/.build
+rm -rf ${projectFolder}/Packages
+ls -la
+rm -rf ${projectFolder}/${SWIFT_SNAPSHOT}
+ls -la

--- a/build-package.sh
+++ b/build-package.sh
@@ -144,13 +144,9 @@ else
 fi
 
 # Clean up build artifacts
-ls -la
 rm -rf ${projectFolder}/.build
-rm -rf ${projectFolder}/Packages
-ls -la
-echo ${SWIFT_SNAPSHOT}-${UBUNTU_VERSION}
 rm -rf ${projectFolder}/${SWIFT_SNAPSHOT}-${UBUNTU_VERSION}
-ls -la
+
 
 # Generate test code coverage report
 sourceScript "${projectFolder}/Package-Builder/codecov.sh"

--- a/build-package.sh
+++ b/build-package.sh
@@ -143,9 +143,6 @@ else
     echo ">> No testcases exist..."
 fi
 
-# Generate test code coverage report
-sourceScript "${projectFolder}/Package-Builder/codecov.sh"
-
 # Clean up build artifacts
 ls -la
 rm -rf ${projectFolder}/.build
@@ -153,3 +150,6 @@ rm -rf ${projectFolder}/Packages
 ls -la
 rm -rf ${projectFolder}/${SWIFT_SNAPSHOT}
 ls -la
+
+# Generate test code coverage report
+sourceScript "${projectFolder}/Package-Builder/codecov.sh"

--- a/build-package.sh
+++ b/build-package.sh
@@ -148,7 +148,8 @@ ls -la
 rm -rf ${projectFolder}/.build
 rm -rf ${projectFolder}/Packages
 ls -la
-rm -rf ${projectFolder}/${SWIFT_SNAPSHOT}
+echo ${SWIFT_SNAPSHOT}-${UBUNTU_VERSION}
+rm -rf ${projectFolder}/${SWIFT_SNAPSHOT}-${UBUNTU_VERSION}
 ls -la
 
 # Generate test code coverage report

--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -27,10 +27,15 @@ set -e
 set -o verbose
 
 sudo apt-get update
+#sudo apt-get -y install clang-3.8 lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev # does not work on Bluemix DevOps Pipeline, using regular clang install instead
 sudo apt-get -y install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev
 
 # Remove default version of clang from PATH
 export PATH=`echo ${PATH} | awk -v RS=: -v ORS=: '/clang/ {next} {print}'`
+
+# Set clang 3.8 as default - does not work on Bluemix DevOps Pipeline, using regular clang install instead
+#sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 100
+#sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100
 
 # Environment vars
 version=`lsb_release -d | awk '{print tolower($2) $3}'`

--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -27,14 +27,10 @@ set -e
 set -o verbose
 
 sudo apt-get update
-sudo apt-get -y install clang-3.8 lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev
+sudo apt-get -y install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev
 
 # Remove default version of clang from PATH
 export PATH=`echo ${PATH} | awk -v RS=: -v ORS=: '/clang/ {next} {print}'`
-
-# Set clang 3.8 as default
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 100
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 100
 
 # Environment vars
 version=`lsb_release -d | awk '{print tolower($2) $3}'`


### PR DESCRIPTION
- Remove build artifacts post completion
- Use `clang` instead of `clang-3.8`