### PR TITLE
Add libz-dev Linux binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,19 +35,19 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=swift-DEVELOPMENT-SNAPSHOT-2017-02-14-a
+      env: SWIFT_SNAPSHOT=swift-DEVELOPMENT-SNAPSHOT-2017-08-15-a
     - os: osx
       osx_image: xcode8.3
       sudo: required
-      env: SWIFT_SNAPSHOT=swift-DEVELOPMENT-SNAPSHOT-2017-02-14-a
+      env: SWIFT_SNAPSHOT=swift-DEVELOPMENT-SNAPSHOT-2017-08-15-a
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=swift-3.1-DEVELOPMENT-SNAPSHOT-2017-03-18-a
+      env: SWIFT_SNAPSHOT=swift-3.1-DEVELOPMENT-SNAPSHOT-2017-06-14-a
     - os: osx
       osx_image: xcode8.3
       sudo: required
-      env: SWIFT_SNAPSHOT=swift-3.1-DEVELOPMENT-SNAPSHOT-2017-03-18-a
+      env: SWIFT_SNAPSHOT=swift-3.1-DEVELOPMENT-SNAPSHOT-2017-06-14-a
 
 script:
   # Set up build structure for test projects

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       sudo: required
       env: SWIFT_SNAPSHOT=swift-DEVELOPMENT-SNAPSHOT-2017-08-15-a
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9
       sudo: required
       env: SWIFT_SNAPSHOT=swift-DEVELOPMENT-SNAPSHOT-2017-08-15-a
     - os: linux

--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -29,7 +29,7 @@ set -e
 sudo apt-get -qq update > /dev/null
 # Following line does not work on Bluemix DevOps Pipeline; hence using regular clang install instead.
 #sudo apt-get -y install clang-3.8 lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev
-sudo apt-get -y -qq install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata > /dev/null
+sudo apt-get -y -qq install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata libz-dev > /dev/null
 
 # Environment vars
 version=`lsb_release -d | awk '{print tolower($2) $3}'`


### PR DESCRIPTION
On Ubuntu 14.04 & Swift 4 08-04 snapshot, [Kitura-Compression](https://github.com/IBM-Swift/Kitura-Compression) fails without `apt-get install libz-dev`:

https://travis-ci.org/IBM-Swift/Kitura-Compression/jobs/260779252

Is adding `libz-dev` here an acceptable solution?