### PR TITLE
Echo swiftlint version

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -146,6 +146,9 @@ if [ "$(uname)" == "Darwin" ]; then
     sed -i '' 's/excluded:/excluded:\
   - Package-Builder/g' ${projectFolder}/.swiftlint.yml
 
+    # Print linter version
+    echo "Running linter swiftlint version $(swiftlint version)"
+
     swiftlint lint --quiet --config ${projectFolder}/.swiftlint.yml
   #else
   #swiftlint lint --quiet --config ${projectFolder}/Package-Builder/.swiftlint.yml


### PR DESCRIPTION
## Description
Echo swiftlint version before swiftlint-ing files

## Motivation and Context

Swiftlint is great but it *adds/changes/removes/deprecates rules* changing the behaviour quite frequently. 

If the developer wants to reproduce same warnings/errors in local computer having a version in the logs helps a lot. This little PR should write something like this:

> Running linter swiftlint version 0.24.0

## How Has This Been Tested?

I just partially executed the script in my local machine

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA) ->
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.


