### PR TITLE
Echo at start of install_swift_binaries.sh

### DIFF
--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -26,7 +26,7 @@ set -e
 # Echo commands before executing them.
 #set -o verbose
 
-echo ">> Running $(basename "$0")"
+echo ">> Running ${BASH_SOURCE[0]}"
 
 sudo apt-get -qq update > /dev/null
 sudo apt-get -y -qq install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata libz-dev > /dev/null

--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -26,6 +26,8 @@ set -e
 # Echo commands before executing them.
 #set -o verbose
 
+echo ">> Running $(basename "$0")"
+
 sudo apt-get -qq update > /dev/null
 sudo apt-get -y -qq install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata libz-dev > /dev/null
 

--- a/osx/install_swift_binaries.sh
+++ b/osx/install_swift_binaries.sh
@@ -24,6 +24,8 @@ set -e
 # Echo commands before executing them.
 #set -o verbose
 
+echo ">> Running $(basename "$0")"
+
 # Install Swift binaries
 # See http://apple.stackexchange.com/questions/72226/installing-pkg-with-terminal
 

--- a/osx/install_swift_binaries.sh
+++ b/osx/install_swift_binaries.sh
@@ -24,7 +24,7 @@ set -e
 # Echo commands before executing them.
 #set -o verbose
 
-echo ">> Running $(basename "$0")"
+echo ">> Running ${BASH_SOURCE[0]}"
 
 # Install Swift binaries
 # See http://apple.stackexchange.com/questions/72226/installing-pkg-with-terminal


### PR DESCRIPTION
This adds an `echo` statement at the start of the script, so we can tell that it's started in CI logs. 

There have been instances of Travis runs that have hung and it hasn't been immediately clear where - e.g. https://travis-ci.org/IBM-Swift/Kitura/jobs/344670075

This would help diagnosis in those cases.