### PR TITLE
Fixes for auto jazzy doc logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ For example, see the [current test coverage](https://codecov.io/gh/IBM-Swift/Swi
 Please note that Codecov is only leveraged when executing builds on the macOS platform. 
 
 ### Auto Jazzy Docs Build
-[Jazzy](https://github.com/realm/jazzy) provides automatic documentation construction. Since developers often forget to update the docs after updating public facing api/documentation, package builder automates the creation and pushing of updated docs to the master branch.
+[Jazzy](https://github.com/realm/jazzy) provides automatic documentation construction. To simplify the process of updating public facing api/documentation, package builder can automate the creation and pushing of updated docs for a Pull Request.
 
-Simply add the `-docs` flag to your build and provide the credentials through the environment variables GITHUB_USERNAME and GITHUB_PASSWORD.
+To indicate that documentation should be generated, add the `jazzy-doc` label to the Pull Request. Credentials must be provided through the environment variables GITHUB_USERNAME and GITHUB_PASSWORD, which should be defined in the Travis configuration for the repository.
+
+Once the regular build has executed, Jazzy will be run for MacOS builds and the resulting documentation pushed to the PR branch in a new `[ci skip]` commit.
 
 ### Custom Xcode project generation
 If for Codecov, you need a custom command to generate the Xcode project for your Swift package, you should include a `.swift-xcodeproj` file that contains your custom `swift package generate-xcodeproj` command.

--- a/build-package.sh
+++ b/build-package.sh
@@ -177,9 +177,8 @@ if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
         echo "Label data retreived: $jsonResponse"
         # candidateTags=`echo $jsonResponse | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w 'name'`
         labelNames=`echo "$jsonResponse" | grep '"name"'`
-        echo "Lines containing labels: $labelNames"
         candidateTags=`echo "$labelNames" | sed -e's#.*"name" *: *"\([^"]*\)".*#\1#'`
-        echo "Label names: $candidateTags"
+        echo "Labels: " $candidateTags
         # Check if the response tag name contains the name 'jazzy-doc'
         if [[ $candidateTags == *"jazzy-doc"* ]]; then
             echo "Documentation tag jazzy-doc exists for this repo"

--- a/build-package.sh
+++ b/build-package.sh
@@ -169,7 +169,7 @@ if [ "$(uname)" == "Darwin" ]; then
 fi
 
 # Generate jazzy docs (macOS) where the 'documentation' tag exists on the issue label
-if [ "$(uname)" == "darwin"* ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
     if  [ -z "${GITHUB_USERNAME}" ] && [ -z "${GITHUB_PASSWORD}" ]; then
 
         # Obtain the name of the tag from the GitHub repo using the GitHub Username and Password, discarding unnecessary text around the retrieved string

--- a/build-package.sh
+++ b/build-package.sh
@@ -170,15 +170,18 @@ fi
 
 # Generate jazzy docs (macOS) where the 'documentation' tag exists on the issue label
 if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+    echo "This is a pull request, running on Darwin"
     if  [ -z "${GITHUB_USERNAME}" ] && [ -z "${GITHUB_PASSWORD}" ]; then
-
+        echo "Github credentials are available"
         # Obtain the name of the tag from the GitHub repo using the GitHub Username and Password, discarding unnecessary text around the retrieved string
         response= curl -s -X GET echo "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/labels" | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w 'name'
-
+        echo "Tags retreived: $response"
         # Check if the response tag name contains the name 'jazzy-doc'
-        if [[ $response = *"jazzy-doc"* ]]; then
-            echo "Documentation tag exists for this repo"
+        if [[ $response == *"jazzy-doc"* ]]; then
+            echo "Documentation tag jazzy-doc exists for this repo"
             sourceScript "${projectFolder}/Package-Builder/jazzy.sh"
+        else
+            echo "No jazzy-doc tag found"
         fi
 
     else

--- a/build-package.sh
+++ b/build-package.sh
@@ -168,18 +168,23 @@ if [ "$(uname)" == "Darwin" ]; then
   fi
 fi
 
-# Generate jazzy docs (macOS) where the 'documentation' tag exists on the issue label
+# Generate jazzy docs (MacOS) for Pull Requests that have the 'jazzy-doc' label.
+# The docs will be generated and pushed as a new [ci skip] commit to the PR branch.
+# Suitable credentials are required for this purpose. These should be defined in
+# the repo's Travis configuration as GITHUB_USERNAME and GITHUB_PASSWORD.
+#
 if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
     if  [ -n "${GITHUB_USERNAME}" -a -n "${GITHUB_PASSWORD}" ]; then
         echo "Checking PR for docs generation tag"
-        # Obtain the name of the tag from the GitHub repo using the GitHub Username and Password, discarding unnecessary text around the retrieved string
+        # Obtain the label information for this PR from the GitHub. This is a JSON document describing each label
         jsonResponse=`curl -s -X GET https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/labels`
-        echo "Label data retreived: $jsonResponse"
+        echo "Label data retrieved: $jsonResponse"
+        # We require only the text of the label - filter on the "name" attribute
         labelNames=`echo "$jsonResponse" | grep '"name"'`
-        # Extract the label name from the "name": "value" pair. This assumes each pair is on a separate line.
+        # Extract the label name from the "name": "value" pair. This assumes each pair is on a separate line
         candidateTags=`echo "$labelNames" | sed -e's#.*"name" *: *"\([^"]*\)".*#\1#'`
         echo "Labels: " $candidateTags
-        # Check if the response tag name contains the name 'jazzy-doc'
+        # Check if any of the labels contain the text 'jazzy-doc'
         if [[ $candidateTags == *"jazzy-doc"* ]]; then
             echo "Documentation tag jazzy-doc exists for this repo"
             sourceScript "${projectFolder}/Package-Builder/jazzy.sh"

--- a/build-package.sh
+++ b/build-package.sh
@@ -174,7 +174,7 @@ if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
     if  [ -z "${GITHUB_USERNAME}" ] && [ -z "${GITHUB_PASSWORD}" ]; then
         echo "Github credentials are available"
         # Obtain the name of the tag from the GitHub repo using the GitHub Username and Password, discarding unnecessary text around the retrieved string
-        response=`curl -s -X GET echo "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/labels"`
+        response=`curl -s -X GET https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/labels`
         responseB=`echo $response | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w 'name'`
         echo "Tags retreived: $response"
         echo "Converted to: $responseB"

--- a/build-package.sh
+++ b/build-package.sh
@@ -174,7 +174,7 @@ if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
         echo "Checking PR for docs generation tag"
         # Obtain the name of the tag from the GitHub repo using the GitHub Username and Password, discarding unnecessary text around the retrieved string
         jsonResponse=`curl -s -X GET https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/labels | grep '"name"'`
-        //candidateTags=`echo $jsonResponse | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w 'name'`
+        # candidateTags=`echo $jsonResponse | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w 'name'`
         candidateTags=`echo $jsonResponse | sed -e's#.*"name" *: *"\([^"]*\).*"#\1#'`
         echo "Tags retreived: $jsonResponse"
         echo "Converted to: $candidateTags"

--- a/build-package.sh
+++ b/build-package.sh
@@ -173,11 +173,13 @@ if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
     if  [ -z "${GITHUB_USERNAME}" ] && [ -z "${GITHUB_PASSWORD}" ]; then
         echo "Checking PR for docs generation tag"
         # Obtain the name of the tag from the GitHub repo using the GitHub Username and Password, discarding unnecessary text around the retrieved string
-        jsonResponse=`curl -s -X GET https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/labels | grep '"name"'`
+        jsonResponse=`curl -s -X GET https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/labels`
+        echo "Label data retreived: $jsonResponse"
         # candidateTags=`echo $jsonResponse | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w 'name'`
-        candidateTags=`echo $jsonResponse | sed -e's#.*"name" *: *"\([^"]*\).*"#\1#'`
-        echo "Tags retreived: $jsonResponse"
-        echo "Converted to: $candidateTags"
+        labelNames=`echo "$jsonResponse" | grep '"name"'`
+        echo "Lines containing labels: $labelNames"
+        candidateTags=`echo "$labelNames" | sed -e's#.*"name" *: *"\([^"]*\)".*#\1#'`
+        echo "Label names: $candidateTags"
         # Check if the response tag name contains the name 'jazzy-doc'
         if [[ $candidateTags == *"jazzy-doc"* ]]; then
             echo "Documentation tag jazzy-doc exists for this repo"

--- a/build-package.sh
+++ b/build-package.sh
@@ -168,7 +168,7 @@ if [ "$(uname)" == "Darwin" ]; then
   fi
 fi
 
-# Generate jazzy docs (MacOS) for Pull Requests that have the 'jazzy-doc' label.
+# Generate jazzy docs (macOS) for Pull Requests that have the 'jazzy-doc' label.
 # The docs will be generated and pushed as a new [ci skip] commit to the PR branch.
 # Suitable credentials are required for this purpose. These should be defined in
 # the repo's Travis configuration as GITHUB_USERNAME and GITHUB_PASSWORD.

--- a/build-package.sh
+++ b/build-package.sh
@@ -174,8 +174,10 @@ if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
     if  [ -z "${GITHUB_USERNAME}" ] && [ -z "${GITHUB_PASSWORD}" ]; then
         echo "Github credentials are available"
         # Obtain the name of the tag from the GitHub repo using the GitHub Username and Password, discarding unnecessary text around the retrieved string
-        response= curl -s -X GET echo "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/labels" | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w 'name'
+        response=`curl -s -X GET echo "https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/labels"`
+        responseB=`echo $response | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w 'name'`
         echo "Tags retreived: $response"
+        echo "Converted to: $responseB"
         # Check if the response tag name contains the name 'jazzy-doc'
         if [[ $response == *"jazzy-doc"* ]]; then
             echo "Documentation tag jazzy-doc exists for this repo"

--- a/build-package.sh
+++ b/build-package.sh
@@ -170,16 +170,16 @@ fi
 
 # Generate jazzy docs (macOS) where the 'documentation' tag exists on the issue label
 if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-    echo "This is a pull request, running on Darwin"
     if  [ -z "${GITHUB_USERNAME}" ] && [ -z "${GITHUB_PASSWORD}" ]; then
-        echo "Github credentials are available"
+        echo "Checking PR for docs generation tag"
         # Obtain the name of the tag from the GitHub repo using the GitHub Username and Password, discarding unnecessary text around the retrieved string
-        response=`curl -s -X GET https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/labels`
-        responseB=`echo $response | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w 'name'`
-        echo "Tags retreived: $response"
-        echo "Converted to: $responseB"
+        jsonResponse=`curl -s -X GET https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/labels | grep '"name"'`
+        //candidateTags=`echo $jsonResponse | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w 'name'`
+        candidateTags=`echo $jsonResponse | sed -e's#.*"name" *: *"\([^"]*\).*"#\1#'`
+        echo "Tags retreived: $jsonResponse"
+        echo "Converted to: $candidateTags"
         # Check if the response tag name contains the name 'jazzy-doc'
-        if [[ $response == *"jazzy-doc"* ]]; then
+        if [[ $candidateTags == *"jazzy-doc"* ]]; then
             echo "Documentation tag jazzy-doc exists for this repo"
             sourceScript "${projectFolder}/Package-Builder/jazzy.sh"
         else

--- a/build-package.sh
+++ b/build-package.sh
@@ -170,13 +170,13 @@ fi
 
 # Generate jazzy docs (macOS) where the 'documentation' tag exists on the issue label
 if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-    if  [ -z "${GITHUB_USERNAME}" ] && [ -z "${GITHUB_PASSWORD}" ]; then
+    if  [ -n "${GITHUB_USERNAME}" -a -n "${GITHUB_PASSWORD}" ]; then
         echo "Checking PR for docs generation tag"
         # Obtain the name of the tag from the GitHub repo using the GitHub Username and Password, discarding unnecessary text around the retrieved string
         jsonResponse=`curl -s -X GET https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/labels`
         echo "Label data retreived: $jsonResponse"
-        # candidateTags=`echo $jsonResponse | sed 's/\\\\\//\//g' | sed 's/[{}]//g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | sed 's/\"\:\"/\|/g' | sed 's/[\,]/ /g' | sed 's/\"//g' | grep -w 'name'`
         labelNames=`echo "$jsonResponse" | grep '"name"'`
+        # Extract the label name from the "name": "value" pair. This assumes each pair is on a separate line.
         candidateTags=`echo "$labelNames" | sed -e's#.*"name" *: *"\([^"]*\)".*#\1#'`
         echo "Labels: " $candidateTags
         # Check if the response tag name contains the name 'jazzy-doc'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I found numerous flaws in the logic for automatic Jazzy generation.  This PR fixes the problems I've found so far.  It is being tested via IBM-Swift/Kitura#1217.  The Kitura Travis configuration has been updated to provide Github credentials as required by this feature.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Jazzy generation did not work at all when testing on IBM-Swift/Kitura#1217

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I temporarily modified the `.travis.yml` for IBM-Swift/Kitura#1217 to point to my fork of Package-Builder containing these changes, then re-ran Travis. This produces a Travis build that can be restarted each time a change to Package-Builder needs to be tested.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
