### PR TITLE
Avoid early exit when grep finds no matches

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -180,7 +180,7 @@ if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
         jsonResponse=`curl -s -X GET https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/labels`
         echo "Label data retrieved: $jsonResponse"
         # We require only the text of the label - filter on the "name" attribute
-        labelNames=`echo "$jsonResponse" | grep '"name"'`
+        labelNames=`echo "$jsonResponse" | grep '"name"' || true`
         # Extract the label name from the "name": "value" pair. This assumes each pair is on a separate line
         candidateTags=`echo "$labelNames" | sed -e's#.*"name" *: *"\([^"]*\)".*#\1#'`
         echo "Labels: " $candidateTags


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds `|| true` to a usage of `grep` to avoid an early exit from `build-package.sh` if it fails to find any matches.

See: https://unix.stackexchange.com/questions/235017/set-e-and-grep-idiom-for-preventing-premature-exit-from-shell-script-when-p

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#130 added a `grep` when checking for labels.  Unfortunately, the combination of `grep` and `sed -e` has to be handled carefully, as the grep command returns a non-zero exit status if it finds no matches, and this causes the script to fail early when testing a Pull Request that has no labels.

Regrettably, the testing for #130 was run only on PRs that had labels.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested the proposed change in isolation in a dummy bash script locally, and it solves the problem.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
