### PR TITLE
Complete jazzy-doc auto documentation feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ matrix:
       osx_image: xcode9
       sudo: required
       env: SWIFT_SNAPSHOT=swift-DEVELOPMENT-SNAPSHOT-2017-08-15-a
+      env: JAZZY_ELIGIBLE=true
     - os: osx
       osx_image: xcode9.2
       sudo: required

--- a/README.md
+++ b/README.md
@@ -84,7 +84,16 @@ Please note that Codecov is only leveraged when executing builds on the macOS pl
 ### Auto Jazzy Docs Build
 [Jazzy](https://github.com/realm/jazzy) provides automatic documentation construction. To simplify the process of updating public facing api/documentation, package builder can automate the creation and pushing of updated docs for a Pull Request.
 
-To indicate that documentation should be generated, add the `jazzy-doc` label to the Pull Request. Credentials must be provided through the environment variables GITHUB_USERNAME and GITHUB_PASSWORD, which should be defined in the Travis configuration for the repository.
+To indicate that documentation should be generated, add the `jazzy-doc` label to the Pull Request.
+
+In order for a PR to receive automatic documentation generation, the following must be configured:
+- The Travis configuration for the repository must define the following environment variables, specifying the credentials of a user that has sufficient permissions to push to PR branches:
+  - `GITHUB_USERNAME`
+  - `GITHUB_PASSWORD`
+  - `GITHUB_EMAIL`
+- The repository must have a `jazzy-doc` label defined
+- The `.travis.yaml` for the project must contain one macOS build with `env: JAZZY_ELIGIBLE=true`
+- The PR must have the `jazzy-doc` label applied
 
 Once the regular build has executed, Jazzy will be run for MacOS builds and the resulting documentation pushed to the PR branch in a new `[ci skip]` commit.
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -56,6 +56,7 @@ if [ -z "$projectBuildDir" ]; then
 fi
 
 # Determine location of this script
+# Ref: https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Utility functions

--- a/build-package.sh
+++ b/build-package.sh
@@ -55,11 +55,14 @@ if [ -z "$projectBuildDir" ]; then
   usage
 fi
 
+# Determine location of this script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 # Utility functions
 function sourceScript () {
   if [ -e "$1" ]; then
     source "$1"
-    echo "$2"
+    echo ">> Completed ${2}."
   fi
 }
 
@@ -81,7 +84,7 @@ projectName="$(basename $projectFolder)"
 echo ">> projectName: $projectName"
 
 # Install swift binaries based on OS
-source ./Package-Builder/install-swift.sh
+source ${SCRIPT_DIR}/install-swift.sh
 
 # Show path
 echo ">> PATH: $PATH"
@@ -119,18 +122,18 @@ fi
 if [ -e "${projectFolder}/Tests" ]; then
     echo ">> Testing Swift package..."
     # Execute OS specific pre-test steps
-    sourceScript "`find ${projectFolder} -path "*/${projectName}/${osName}/before_tests.sh" -not -path "*/Package-Builder/*" -not -path "*/Packages/*"`" ">> Completed ${osName} pre-tests steps."
+    sourceScript "`find ${projectFolder} -path "*/${projectName}/${osName}/before_tests.sh" -not -path "*/Package-Builder/*" -not -path "*/Packages/*"`" "${osName} pre-tests steps"
 
     # Execute common pre-test steps
-    sourceScript "`find ${projectFolder} -path "*/${projectName}/common/before_tests.sh" -not -path "*/Package-Builder/*" -not -path "*/Packages/*"`" ">> Completed common pre-tests steps."
+    sourceScript "`find ${projectFolder} -path "*/${projectName}/common/before_tests.sh" -not -path "*/Package-Builder/*" -not -path "*/Packages/*"`" "common pre-tests steps"
 
-    source ./Package-Builder/run_tests.sh
+    source ${SCRIPT_DIR}/run_tests.sh
 
     # Execute common post-test steps
-    sourceScript "`find ${projectFolder} -path "*/${projectName}/common/after_tests.sh" -not -path "*/Package-Builder/*" -not -path "*/Packages/*"`" ">> Completed common post-tests steps."
+    sourceScript "`find ${projectFolder} -path "*/${projectName}/common/after_tests.sh" -not -path "*/Package-Builder/*" -not -path "*/Packages/*"`" "common post-tests steps"
 
     # Execute OS specific post-test steps
-    sourceScript "`find ${projectFolder} -path "*/${projectName}/${osName}/after_tests.sh" -not -path "*/Package-Builder/*" -not -path "*/Packages/*"`" ">> Completed ${osName} post-tests steps."
+    sourceScript "`find ${projectFolder} -path "*/${projectName}/${osName}/after_tests.sh" -not -path "*/Package-Builder/*" -not -path "*/Packages/*"`" "${osName} post-tests steps"
 
     echo ">> Finished testing Swift package."
     echo
@@ -164,16 +167,21 @@ if [ "$(uname)" == "Darwin" ]; then
   if [ -e ${projectFolder}/.swift-codecov ]; then
       source ${projectFolder}/.swift-codecov
   else
-      sourceScript "${projectFolder}/Package-Builder/codecov.sh"
+      sourceScript "${SCRIPT_DIR}/codecov.sh" "codecov generation"
   fi
 fi
 
 # Generate jazzy docs (macOS) for Pull Requests that have the 'jazzy-doc' label.
 # The docs will be generated and pushed as a new [ci skip] commit to the PR branch.
+#
 # Suitable credentials are required for this purpose. These should be defined in
 # the repo's Travis configuration as GITHUB_USERNAME and GITHUB_PASSWORD.
 #
-if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ] && [ $JAZZY_ELIGIBLE ]; then
+# Additionally, the Travis build must have the JAZZY_ELIGIBLE environment variable
+# defined, and this should be defined on only one macOS build, to ensure that only
+# one build (per commit) produces a documentation commit.
+#
+if [ "$(uname)" == "Darwin" -a "${TRAVIS_PULL_REQUEST}" != "false" -a -n "${JAZZY_ELIGIBLE}" ]; then
     if  [ -n "${GITHUB_USERNAME}" -a -n "${GITHUB_PASSWORD}" ]; then
         echo "Checking PR for docs generation tag"
         # Obtain the label information for this PR from the GitHub. This is a JSON document describing each label
@@ -187,7 +195,7 @@ if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ] && [ $J
         # Check if any of the labels contain the text 'jazzy-doc'
         if [[ $candidateTags == *"jazzy-doc"* ]]; then
             echo "Documentation tag jazzy-doc exists for this repo"
-            sourceScript "${projectFolder}/Package-Builder/jazzy.sh"
+            sourceScript "${SCRIPT_DIR}/jazzy.sh" "jazzy-doc generation"
         else
             echo "No jazzy-doc tag found"
         fi

--- a/build-package.sh
+++ b/build-package.sh
@@ -173,7 +173,7 @@ fi
 # Suitable credentials are required for this purpose. These should be defined in
 # the repo's Travis configuration as GITHUB_USERNAME and GITHUB_PASSWORD.
 #
-if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+if [ "$(uname)" == "Darwin" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ] && [ $JAZZY_ELIGIBLE ]; then
     if  [ -n "${GITHUB_USERNAME}" -a -n "${GITHUB_PASSWORD}" ]; then
         echo "Checking PR for docs generation tag"
         # Obtain the label information for this PR from the GitHub. This is a JSON document describing each label

--- a/jazzy.sh
+++ b/jazzy.sh
@@ -22,23 +22,24 @@ if [ -z "${GITHUB_USERNAME}" ] && [ -z "${GITHUB_PASSWORD}" ]; then
 fi
 
 # Check if .jazzy.yaml exists in the root folder of the repo
-#cd ..
-export projectFolder=`pwd`
-
-if [ -e ./$(projectFolder) ]; then
-
-    # Install jazzy
-    sudo gem install jazzy
-    # Generate xcode project
-    sourceScript "${projectFolder}/generate-xcodeproj.sh"
-    # Run jazzy
-    jazzy
-
-    # Configure endpoint
-    REPO=`git config remote.origin.url`
-    AUTH_REPO=${REPO/https:\/\/github.com\//https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/}
-  
-    git add docs/.
-    git commit -m 'Documentation update [ci skip]'
-    git push
+if [ ! -f "/.jazzy.yaml" ] then
+    echo ".jazzy.yaml file does not exist"
 fi
+
+# Install jazzy
+sudo gem install jazzy
+# Generate xcode project
+sourceScript "/generate-xcodeproj.sh"
+# Run jazzy
+jazzy
+
+# Checkout to the current branch
+git checkout "${TRAVIS_PULL_REQUEST_BRANCH}"
+
+# Configure endpoint
+REPO=`git config remote.origin.url`
+AUTH_REPO=${REPO/https:\/\/github.com\//https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/}
+
+git add docs/.
+git commit -m 'Documentation update [ci skip]'
+git push

--- a/jazzy.sh
+++ b/jazzy.sh
@@ -14,14 +14,17 @@
 # limitations under the License.
 ##
 
-# Check that we have credentials
-if [ -z "${GITHUB_USERNAME}" ] && [ -z "${GITHUB_PASSWORD}" ]; then
+# Check that we have credentials. In addition to the username and password,
+# we require an e-mail address for configuring our user when pushing docs
+# updates back to Github.
+if [ -z "${GITHUB_USERNAME}" -o -z "${GITHUB_PASSWORD}" -o -z "${GITHUB_EMAIL}" ]; then
     echo "Supplied jazzy docs flag, but credentials were not provided."
-    echo "Expected: GITHUB_USER && GITHUB_PASSWORD Env variables."
+    echo "Expected: GITHUB_USER, GITHUB_PASSWORD and GITHUB_EMAIL Env variables."
     exit 1
 fi
 
-# Check that projectFolder and SCRIPT_DIR exist
+# Check that projectFolder and SCRIPT_DIR exist. These should have been set
+# by the calling script (build-package.sh)
 if [ -z "${projectFolder}" ]; then
     projectFolder="$pwd"
     echo "Warning: projectFolder not set. Defaulting to pwd ($projectFolder)"
@@ -33,16 +36,17 @@ if [ -z "${SCRIPT_DIR}" ]; then
     echo "Warning: SCRIPT_DIR not set. Defaulting to current script location ($SCRIPT_DIR}"
 fi
 
-# Check if .jazzy.yaml exists in the root folder of the repo
+# Check if .jazzy.yaml exists in the root folder of the repo. If we do not find
+# it, fail the build because the build explicitly requested docs generation.
 if [ ! -f "${projectFolder}/.jazzy.yaml" ]; then
     echo ".jazzy.yaml file does not exist"
     exit 1
 fi
 
 # Checkout to the current branch. The repo cloned by Travis is a shallow clone,
-# so we cannot just check out the branch. Instead, create a new remote for this
-# purpose and checkout the branch from there.
-git remote add jazzy https://github.com/${TRAVIS_REPO_SLUG}.git
+# so we cannot check out the branch directly. Instead, create a new remote for
+# this purpose and checkout the branch from there.
+git remote add jazzy https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/${TRAVIS_REPO_SLUG}.git
 git fetch jazzy
 git checkout jazzy/${TRAVIS_PULL_REQUEST_BRANCH} -b ${TRAVIS_PULL_REQUEST_BRANCH}
 
@@ -53,10 +57,12 @@ sourceScript "${SCRIPT_DIR}/generate-xcodeproj.sh" "xcodeproj generation"
 # Run jazzy
 jazzy
 
-# Configure endpoint
-REPO=`git config remote.origin.url`
-AUTH_REPO=${REPO/https:\/\/github.com\//https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/}
+# Configure user
+git config --global --add user.name Auto-Jazzy
+git config --global --add user.email ${GITHUB_EMAIL}
+git config --global --add push.default simple
 
+# Push the updated docs as a new commit to the PR branch
 git add docs/.
 git commit -m 'Documentation update [ci skip]'
 git push

--- a/jazzy.sh
+++ b/jazzy.sh
@@ -24,7 +24,11 @@ fi
 # Check if .jazzy.yaml exists in the root folder of the repo
 if [ ! -f "/.jazzy.yaml" ] then
     echo ".jazzy.yaml file does not exist"
+    exit 1
 fi
+
+# Checkout to the current branch
+git checkout "${TRAVIS_PULL_REQUEST_BRANCH}"
 
 # Install jazzy
 sudo gem install jazzy
@@ -32,9 +36,6 @@ sudo gem install jazzy
 sourceScript "/generate-xcodeproj.sh"
 # Run jazzy
 jazzy
-
-# Checkout to the current branch
-git checkout "${TRAVIS_PULL_REQUEST_BRANCH}"
 
 # Configure endpoint
 REPO=`git config remote.origin.url`

--- a/jazzy.sh
+++ b/jazzy.sh
@@ -21,8 +21,20 @@ if [ -z "${GITHUB_USERNAME}" ] && [ -z "${GITHUB_PASSWORD}" ]; then
     exit 1
 fi
 
+# Check that projectFolder and SCRIPT_DIR exist
+if [ -z "${projectFolder}" ]; then
+    projectFolder="$pwd"
+    echo "Warning: projectFolder not set. Defaulting to pwd ($projectFolder)"
+fi
+
+if [ -z "${SCRIPT_DIR}" ]; then
+    # Determine location of this script
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    echo "Warning: SCRIPT_DIR not set. Defaulting to current script location ($SCRIPT_DIR}"
+fi
+
 # Check if .jazzy.yaml exists in the root folder of the repo
-if [ ! -f "/.jazzy.yaml" ] then
+if [ ! -f "${projectFolder}/.jazzy.yaml" ]; then
     echo ".jazzy.yaml file does not exist"
     exit 1
 fi
@@ -33,7 +45,7 @@ git checkout "${TRAVIS_PULL_REQUEST_BRANCH}"
 # Install jazzy
 sudo gem install jazzy
 # Generate xcode project
-sourceScript "/generate-xcodeproj.sh"
+sourceScript "${SCRIPT_DIR}/generate-xcodeproj.sh" "xcodeproj generation"
 # Run jazzy
 jazzy
 

--- a/jazzy.sh
+++ b/jazzy.sh
@@ -39,8 +39,12 @@ if [ ! -f "${projectFolder}/.jazzy.yaml" ]; then
     exit 1
 fi
 
-# Checkout to the current branch
-git checkout "${TRAVIS_PULL_REQUEST_BRANCH}"
+# Checkout to the current branch. The repo cloned by Travis is a shallow clone,
+# so we cannot just check out the branch. Instead, create a new remote for this
+# purpose and checkout the branch from there.
+git remote add jazzy https://github.com/${TRAVIS_REPO_SLUG}.git
+git fetch jazzy
+git checkout jazzy/${TRAVIS_PULL_REQUEST_BRANCH} -b ${TRAVIS_PULL_REQUEST_BRANCH}
 
 # Install jazzy
 sudo gem install jazzy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replaces #131 in order to fix additional problems in the `jazzy.sh` script.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Completes implementation of auto-jazzy documentation generation for appropriately configured repositories and pull requests, which has been implemented via #125, #128 and #130.

### Configuration Dependencies
In order for a PR to receive automatic documentation generation, the following must be configured:
- The Travis configuration for the repository must define the following environment variables, specifying the credentials of a user that has sufficient permissions to push to PR branches:
  - `GITHUB_USERNAME`
  - `GITHUB_PASSWORD`
  - `GITHUB_EMAIL`
- The repository must have a `jazzy-doc` label defined
- The `.travis.yaml` for the project must contain one osx build with `env: JAZZY_ELIGIBLE=true`
- The PR must have the `jazzy-doc` label applied

My recommendation for procedure is as follows:
1. Open a PR that requires documentation generation as normal
2. Obtain reviewer approval and complete any final edits
3. Apply the `jazzy-doc` tag, and restart CI to generate the documentation commit
4. Merge as normal

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was tested via https://github.com/IBM-Swift/Kitura/pull/1217, specifically https://travis-ci.org/IBM-Swift/Kitura/jobs/353911247

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
