### PR TITLE
Set jazzy version to 0.9.1

### DIFF
--- a/jazzy.sh
+++ b/jazzy.sh
@@ -50,8 +50,8 @@ git remote add jazzy https://${GITHUB_USERNAME}:${GITHUB_PASSWORD}@github.com/${
 git fetch jazzy
 git checkout jazzy/${TRAVIS_PULL_REQUEST_BRANCH} -b ${TRAVIS_PULL_REQUEST_BRANCH}
 
-# Install jazzy
-sudo gem install jazzy
+# Install jazzy (version set to 0.9.1 until https://github.com/realm/jazzy/issues/972 is fixed)
+sudo gem install jazzy -v 0.9.1
 # Generate xcode project
 sourceScript "${SCRIPT_DIR}/generate-xcodeproj.sh" "xcodeproj generation"
 # Run jazzy


### PR DESCRIPTION
## Description
Set jazzy version to 0.9.1

## Motivation and Context
Workaround to allow jazzy doc to build for IBM-Swift\HeliumLogger which fails on jazzy 0.9.2 and later with https://github.com/realm/jazzy/issues/972

## How Has This Been Tested?
This command has been tested locally on the command line.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.