### PR TITLE
Fix jazzy-doc generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ In order for a PR to receive automatic documentation generation, the following m
 - The `.travis.yaml` for the project must contain one macOS build with `env: JAZZY_ELIGIBLE=true`
 - The PR must have the `jazzy-doc` label applied
 
-Once the regular build has executed, Jazzy will be run for MacOS builds and the resulting documentation pushed to the PR branch in a new `[ci skip]` commit.
+Once the regular build has executed, Jazzy will be run for MacOS builds and the resulting documentation pushed to the PR branch in a new `[jazzy-doc]` commit. Docs will be generated for each new commit to the PR branch whose commit message does not contain the text `[jazzy-doc]`.
 
 ### Custom Xcode project generation
 If for Codecov, you need a custom command to generate the Xcode project for your Swift package, you should include a `.swift-xcodeproj` file that contains your custom `swift package generate-xcodeproj` command.

--- a/build-package.sh
+++ b/build-package.sh
@@ -163,8 +163,9 @@ if [ "$(uname)" == "Darwin" ]; then
   fi
 fi
 
-# Generate test code coverage report (macOS)
-if [ "$(uname)" == "Darwin" ]; then
+# Generate test code coverage report (macOS). The Travis build must have the
+# CODECOV_ELIGIBLE environment variable defined.
+if [ "$(uname)" == "Darwin" -a -n "${CODECOV_ELIGIBLE}" ]; then
   if [ -e ${projectFolder}/.swift-codecov ]; then
       source ${projectFolder}/.swift-codecov
   else
@@ -183,6 +184,7 @@ fi
 # one build (per commit) produces a documentation commit.
 #
 if [ "$(uname)" == "Darwin" -a "${TRAVIS_PULL_REQUEST}" != "false" -a -n "${JAZZY_ELIGIBLE}" ]; then
+  if [ "${TRAVIS_PULL_REQUEST_SLUG}" == "${TRAVIS_REPO_SLUG}" ]; then
     if  [ -n "${GITHUB_USERNAME}" -a -n "${GITHUB_PASSWORD}" ]; then
         echo "Checking PR for docs generation tag"
         # Obtain the label information for this PR from the GitHub. This is a JSON document describing each label
@@ -198,14 +200,17 @@ if [ "$(uname)" == "Darwin" -a "${TRAVIS_PULL_REQUEST}" != "false" -a -n "${JAZZ
             echo "Documentation tag jazzy-doc exists for this repo"
             sourceScript "${SCRIPT_DIR}/jazzy.sh" "jazzy-doc generation"
         else
-            echo "No jazzy-doc tag found"
+            echo "Note: No jazzy-doc tag found."
         fi
 
     else
-        echo "Expected: GITHUB_USER && GITHUB_PASSWORD Env variables."
+        echo "Error: Expected GITHUB_USERNAME && GITHUB_PASSWORD Env variables."
     fi
+  else
+      echo "Error: jazzy-doc generation cannot be performed from a fork."
+  fi
 else
-    echo "Expected this to be a pull request. Skipping Jazzy docs generation."
+    echo "Note: Build not eligible for jazzy doc generation."
 fi
 
 # Clean up build artifacts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replaces the `[ci skip]` text for jazzy-doc automated commits with `[jazzy-doc]`, and skips generating jazzy documentation if the latest commit message contains `[jazzy-doc]`.

I also tidied up some of the informational messages around the detection of jazzy-doc tags and required environment variables,  and generate a more specific message in the case of a PR from a fork (we do not support jazzy generation for PRs from forks).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is a bug relating to the integration of Travis status and Github PRs (https://github.com/travis-ci/travis-ci/issues/2159), such that if the most recent commit contains `[ci skip]`, the PR gets stuck waiting for Travis to run, rather than taking the previous CI result.  This results in an administrator having to use privilege to merge a PR.

Another result of this change is that the docs commit itself does get CI run against it - so if the docs generation were to somehow check in rogue changes, they would be tested.

The `[jazzy-doc]` commit message detection is required to avoid endlessly generating doc commits.  Unfortunately, we can't use `TRAVIS_COMMIT_MESSAGE` and have to go to git directly to get at it, because for PRs, the commit message is for the merge commit that Travis creates locally when testing a PR.  I've coded the extraction of the commit message from the git command line fairly defensively because we don't want this to break (as it could result in endless commits).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested using this branch in this PR:
https://github.com/IBM-Swift/Kitura-Markdown/pull/16

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
