### PR TITLE
wget: use -nv for quieter output

### DIFF
--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -39,7 +39,7 @@ export UBUNTU_VERSION_NO_DOTS=`echo $version | awk -F. '{print $1$2}'`
 echo ">> Installing '${SWIFT_SNAPSHOT}'..."
 # Install Swift compiler
 cd $projectFolder
-wget https://swift.org/builds/$SNAPSHOT_TYPE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz
+wget -nv https://swift.org/builds/$SNAPSHOT_TYPE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz
 tar xzf $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz
 export PATH=$projectFolder/$SWIFT_SNAPSHOT-$UBUNTU_VERSION/usr/bin:$PATH
 rm $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz

--- a/osx/install_swift_binaries.sh
+++ b/osx/install_swift_binaries.sh
@@ -36,7 +36,7 @@ brew install wget > /dev/null || brew outdated wget > /dev/null || brew upgrade 
 
 #Download and install Swift
 echo "Swift installed $SWIFT_PREINSTALL does not match snapshot $SWIFT_SNAPSHOT."
-wget https://swift.org/builds/$SNAPSHOT_TYPE/xcode/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-osx.pkg
+wget -nv https://swift.org/builds/$SNAPSHOT_TYPE/xcode/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-osx.pkg
 sudo installer -pkg $SWIFT_SNAPSHOT-osx.pkg -target /
 export PATH=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin:"${PATH}"
 rm $SWIFT_SNAPSHOT-osx.pkg


### PR DESCRIPTION
`wget` is verbose by default, which generates a lot of noise in CI logs. For example, see https://travis-ci.org/IBM-Swift/Kitura/jobs/417010428

Use `-nv` which is quieter (but not completely silent).