### PR TITLE
Use wget --progress=dot:giga for low-verbosity progress

### DIFF
--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -39,7 +39,7 @@ export UBUNTU_VERSION_NO_DOTS=`echo $version | awk -F. '{print $1$2}'`
 echo ">> Installing '${SWIFT_SNAPSHOT}'..."
 # Install Swift compiler
 cd $projectFolder
-wget --no-verbose https://swift.org/builds/$SNAPSHOT_TYPE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz
+wget --progress=dot:giga https://swift.org/builds/$SNAPSHOT_TYPE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz
 tar xzf $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz
 export PATH=$projectFolder/$SWIFT_SNAPSHOT-$UBUNTU_VERSION/usr/bin:$PATH
 rm $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz

--- a/linux/install_swift_from_url.sh
+++ b/linux/install_swift_from_url.sh
@@ -34,7 +34,7 @@ sudo apt-get -y -qq install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-d
 echo ">> Installing '${SWIFT_SNAPSHOT}'..."
 # Install Swift compiler
 cd $projectFolder
-wget --no-verbose $SWIFT_SNAPSHOT
+wget --progress=dot:giga $SWIFT_SNAPSHOT
 FILENAME=$(echo $SWIFT_SNAPSHOT | rev | cut -d/ -f1 | rev)
 tar xzf $FILENAME
 SWIFT_FOLDER=$(basename -s .tar.gz $FILENAME)

--- a/osx/install_swift_binaries.sh
+++ b/osx/install_swift_binaries.sh
@@ -36,7 +36,7 @@ brew install wget > /dev/null || brew outdated wget > /dev/null || brew upgrade 
 
 #Download and install Swift
 echo "Swift installed $SWIFT_PREINSTALL does not match snapshot $SWIFT_SNAPSHOT."
-wget --no-verbose https://swift.org/builds/$SNAPSHOT_TYPE/xcode/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-osx.pkg
+wget --progress=dot:giga https://swift.org/builds/$SNAPSHOT_TYPE/xcode/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-osx.pkg
 sudo installer -pkg $SWIFT_SNAPSHOT-osx.pkg -target /
 export PATH=/Library/Developer/Toolchains/swift-latest.xctoolchain/usr/bin:"${PATH}"
 rm $SWIFT_SNAPSHOT-osx.pkg


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR replaces the wget `--no-verbose` option with the `--progress` option using the `dot:giga` style, which prints a single period for each MB of download completed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#136 / #138 added `-nv` / `--no-verbose` to the wget commands used to download from swift.org, to reduce the amount of log noise in Travis builds.  However, if downloads from swift.org are really slow, the builds have a habit of timing out after 10 minutes with no output.

Using `--progress=dot:giga` equates to a little activity to appease Travis and let you see what's going on.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
