### PR TITLE
Debug hangs with Travis Linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=swift-4.2-DEVELOPMENT-SNAPSHOT-2018-06-19-a
+      env: SWIFT_SNAPSHOT=4.2
     - os: osx
       osx_image: xcode9.2
       sudo: required

--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -31,8 +31,8 @@ echo ">> Running ${BASH_SOURCE[0]}"
 # Suppress prompts of any kind while executing apt-get
 export DEBIAN_FRONTEND="noninteractive"
 
-sudo -E apt-get -qq update > /dev/null
-sudo -E apt-get -y -qq install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata libz-dev > /dev/null
+sudo -E apt-get -q update
+sudo -E apt-get -y -q install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata libz-dev
 
 # Environment vars
 version=`lsb_release -d | awk '{print tolower($2) $3}'`

--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -28,8 +28,11 @@ set -e
 
 echo ">> Running ${BASH_SOURCE[0]}"
 
-sudo apt-get -qq update > /dev/null
-sudo apt-get -y -qq install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata libz-dev > /dev/null
+# Suppress prompts of any kind while executing apt-get
+export DEBIAN_FRONTEND="noninteractive"
+
+sudo -E apt-get -qq update > /dev/null
+sudo -E apt-get -y -qq install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata libz-dev > /dev/null
 
 # Environment vars
 version=`lsb_release -d | awk '{print tolower($2) $3}'`

--- a/linux/install_swift_from_url.sh
+++ b/linux/install_swift_from_url.sh
@@ -28,8 +28,11 @@ set -e
 
 echo ">> Running ${BASH_SOURCE[0]}"
 
-sudo apt-get -qq update > /dev/null
-sudo apt-get -y -qq install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata libz-dev > /dev/null
+# Suppress prompts of any kind while executing apt-get
+export DEBIAN_FRONTEND="noninteractive"
+
+sudo -E apt-get -qq update > /dev/null
+sudo -E apt-get -y -qq install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata libz-dev > /dev/null
 
 echo ">> Installing '${SWIFT_SNAPSHOT}'..."
 # Install Swift compiler

--- a/linux/install_swift_from_url.sh
+++ b/linux/install_swift_from_url.sh
@@ -31,8 +31,8 @@ echo ">> Running ${BASH_SOURCE[0]}"
 # Suppress prompts of any kind while executing apt-get
 export DEBIAN_FRONTEND="noninteractive"
 
-sudo -E apt-get -qq update > /dev/null
-sudo -E apt-get -y -qq install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata libz-dev > /dev/null
+sudo -E apt-get -q update
+sudo -E apt-get -y -q install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata libz-dev
 
 echo ">> Installing '${SWIFT_SNAPSHOT}'..."
 # Install Swift compiler


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds `DEBIAN_FRONTEND=noninteractive` environment for the `apt-get` commands when preparing to install Swift, to suppress prompts for input.

Also removes the output suppression for `apt-get` so that we can see what is going wrong when Linux builds hang at this stage.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Travis will hang if apt-get installs a package that prompts for input.  It also seems to be able to hang for other reasons that are not yet clear, as the output is currently redirected to /dev/null.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
