### PR TITLE
Use more portable check for script existence

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -104,7 +104,7 @@ echo ">> Building Swift package..."
 
 cd ${projectFolder}
 
-if [ -v CUSTOM_BUILD_SCRIPT ] && [ -e ${projectFolder}/$CUSTOM_BUILD_SCRIPT ]; then
+if [ -n "${CUSTOM_BUILD_SCRIPT}" ] && [ -e ${projectFolder}/$CUSTOM_BUILD_SCRIPT ]; then
   echo Running custom build command: `cat ${projectFolder}/$CUSTOM_BUILD_SCRIPT`
   source ${projectFolder}/$CUSTOM_BUILD_SCRIPT
 elif [ -e ${projectFolder}/.swift-build-macOS ] && [ "${osName}" == "osx" ]; then

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -18,7 +18,7 @@
 
 set +e                   # do not exit immediately temporarily so we can generate a backtrace for any crash
 ulimit -c unlimited      # enable core file generation
-if [ -v CUSTOM_TEST_SCRIPT ] && [ -e ${projectFolder}/$CUSTOM_TEST_SCRIPT ]; then
+if [ -n "${CUSTOM_TEST_SCRIPT}" ] && [ -e ${projectFolder}/$CUSTOM_TEST_SCRIPT ]; then
   echo ">> Running custom test command: $(cat ${projectFolder}/$CUSTOM_TEST_SCRIPT)"
   source ${projectFolder}/$CUSTOM_TEST_SCRIPT
 elif [ -e ${projectFolder}/.swift-test-macOS ] && [ "$osName" == "osx" ]; then


### PR DESCRIPTION
This PR updates the build and test scripts to use a more portable check when evaluating whether the custom script environment variable exists.

The previous check would not work on Mac OS as it is on an older version of bash.