### PR TITLE
Add support for running inside a DOCKER_IMAGE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,10 @@ script:
   - rm ../executable-no-swift-version/.swift-version
   # This tests Package-Builder with a library
   - cd ../library
-  - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR/library
+  - ./Package-Builder/build-package.sh -projectDir $PWD
   # This tests Package-Builder with an executable
   - cd ../executable
-  - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR/executable
+  - ./Package-Builder/build-package.sh -projectDir $PWD
   # Test building a package that does not have a .swift-version file
   - cd ../executable-no-swift-version
-  - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR/executable-no-swift-version
+  - ./Package-Builder/build-package.sh -projectDir $PWD

--- a/README.md
+++ b/README.md
@@ -168,6 +168,33 @@ script:
 
 In this example above, the first build uses the version specified in the `.swift-version` of the project, or the default version supported by Package-Builder.  The second one declares a `SWIFT_SNAPSHOT` environment variable, which overrides the default and `.swift-version` versions for that build.
 
+### Testing under Docker
+To test your package using a different version of Linux, add the `DOCKER_IMAGE` environment variable to your `.travis.yml` file in each one of the entries under the matrix section as shown below:
+```
+$ cat .travis.yml
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.1.3
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=4.1.3
+
+before_install:
+  - git clone https://github.com/IBM-Swift/Package-Builder.git
+
+script:
+  - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR
+```
+
+In the above example, the first build uses Ubuntu 14.04 (Trusty) which is supported natively by Travis. The second build uses Trusty to download a 16.04 (Xenial) Docker container, and will then re-execute the Package-Builder command within that container.
+
+Selected environment variables are passed through to the container. These are currently: `SWIFT_SNAPSHOT`, `KITURA_NIO`, `GCD_ASYNCH` and `TESTDB_NAME`.
+
 ### Custom build and test commands
 If you need a custom command for **compiling** your Swift package, you should include a `.swift-build-linux` or `.swift-build-macOS` file in the root level of your repository and specify in it the exact compilation command for the corresponding platform.
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -86,7 +86,7 @@ if [ -n "${DOCKER_IMAGE}" ]; then
   echo ">> Executing build in Docker container: ${DOCKER_IMAGE}"
   set -x
   docker pull ${DOCKER_IMAGE}
-  docker run --env SWIFT_SNAPSHOT --env KITURA_NIO --env GCD_ASYNCH --env TESTDB_NAME -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 pkg-config && cd $TRAVIS_BUILD_DIR && ./Package-Builder/build-package.sh ${PACKAGE_BUILDER_ARGS}"
+  docker run --env SWIFT_SNAPSHOT --env KITURA_NIO --env GCD_ASYNCH --env TESTDB_NAME -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 pkg-config libpq-dev && cd $TRAVIS_BUILD_DIR && ./Package-Builder/build-package.sh ${PACKAGE_BUILDER_ARGS}"
   set +x
   DOCKER_RC=$?
   echo ">> Docker execution complete, RC=${DOCKER_RC}"

--- a/build-package.sh
+++ b/build-package.sh
@@ -86,7 +86,7 @@ if [ -n "${DOCKER_IMAGE}" ]; then
   echo ">> Executing build in Docker container: ${DOCKER_IMAGE}"
   set -x
   docker pull ${DOCKER_IMAGE}
-  docker run --env SWIFT_SNAPSHOT --env KITURA_NIO --env GCD_ASYNCH --env TESTDB_NAME -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 pkg-config libpq-dev && cd $TRAVIS_BUILD_DIR && ./Package-Builder/build-package.sh ${PACKAGE_BUILDER_ARGS}"
+  docker run --env SWIFT_SNAPSHOT --env KITURA_NIO --env GCD_ASYNCH --env TESTDB_NAME -v ${projectBuildDir}:${projectBuildDir} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 pkg-config libpq-dev && cd $projectBuildDir && ./Package-Builder/build-package.sh ${PACKAGE_BUILDER_ARGS}"
   set +x
   DOCKER_RC=$?
   echo ">> Docker execution complete, RC=${DOCKER_RC}"

--- a/build-package.sh
+++ b/build-package.sh
@@ -33,6 +33,10 @@ function usage {
   exit 1
 }
 
+# Capture full command line in case we need to re-execute inside Docker
+PACKAGE_BUILDER_ARGS="$*"
+
+# Consume command line options
 while [ $# -ne 0 ]
 do
   case "$1" in
@@ -66,6 +70,28 @@ function sourceScript () {
     echo ">> Completed ${2}."
   fi
 }
+
+# If we have been asked to run within a Docker image, pull the image, then execute
+# this script within the container.
+#
+# Note: environment variables must be explicitly propagated to the container. The
+# ones we currently recognize are:
+#
+# - SWIFT_SNAPSHOT: the Swift toolchain to be used,
+# - KITURA_NIO: an optional compilation mode switch for Kitura,
+# - GCD_ASYNCH: an optional compilation mode switch for Kitura-net,
+# - TESTDB_NAME: the name of a database to be accessed during the build.
+#
+if [ -n "${DOCKER_IMAGE}" ]; then
+  echo ">> Executing build in Docker container: ${DOCKER_IMAGE}"
+  set -x
+  docker pull ${DOCKER_IMAGE}
+  docker run --env SWIFT_SNAPSHOT --env KITURA_NIO --env GCD_ASYNCH --env TESTDB_NAME -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 pkg-config && cd $TRAVIS_BUILD_DIR && ./Package-Builder/build-package.sh ${PACKAGE_BUILDER_ARGS}"
+  set +x
+  DOCKER_RC=$?
+  echo ">> Docker execution complete, RC=${DOCKER_RC}"
+  exit ${DOCKER_RC}
+fi
 
 # Determine platform/OS and project name
 echo ">> uname: $(uname)"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows execution of Package-Builder from a Travis build within a Docker container by setting `DOCKER_IMAGE` to the name of an Ubuntu image, for example `ubuntu:16.04` or `ubuntu:18.04`.

## Motivation and Context
Kitura uses an intermediate `build.sh` to execute Package-Builder from within a Docker container for the purposes of testing with Ubuntu 16.04.  However, this script has to be duplicated to every repo that wants to use this facility, and since Ubuntu 16.04 and 18.04 are still not available natively under Travis, this is something we will increasingly need to rely on for proper coverage.

This PR bakes in that functionality and removes the need for an intermediate script, allowing all repositories to define `DOCKER_IMAGE` with no additional changes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run against Kitura using this branch: https://travis-ci.org/IBM-Swift/Kitura/builds/449785589
Run against Kitura-CouchDB (which additionally passes through testing credentials): https://travis-ci.org/IBM-Swift/Kitura-CouchDB/builds/449799857
(note, the 18.04 build intentionally failed, and is an example of the status from within the Docker container propagating to the top level).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
