### PR TITLE
Allow Docker customization with DOCKER_ENVIRONMENT and DOCKER_PACKAGES

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,19 @@ script:
 
 In the above example, the first build uses Ubuntu 14.04 (Trusty) which is supported natively by Travis. The second build uses Trusty to download a 16.04 (Xenial) Docker container, and will then re-execute the Package-Builder command within that container.
 
-Selected environment variables are passed through to the container. These are currently: `SWIFT_SNAPSHOT`, `KITURA_NIO`, `GCD_ASYNCH` and `TESTDB_NAME`.
+#### Additional environment variables
+
+Selected environment variables are passed through to the container. These are currently: `SWIFT_SNAPSHOT`, `KITURA_NIO`, `GCD_ASYNCH` and `TESTDB_NAME`. Additional environment variables can be passed through by setting the `DOCKER_ENVIRONMENT` variable as follows:
+```
+      env: DOCKER_IMAGE=ubuntu:16.04 DOCKER_ENVIRONMENT="CUSTOMENV1 CUSTOMENV2"
+```
+
+#### Additional system packages
+
+A number of system packages are installed within the Docker container by default (this includes `git`, `wget` and `libxml2`). Additional system package dependencies can be specified by setting the `DOCKER_PACKAGES` variable as follows:
+```
+      env: DOCKER_IMAGE=ubuntu:16.04 DOCKER_PACKAGES="libSomePackage someOtherPackage"
+```
 
 ### Custom build and test commands
 If you need a custom command for **compiling** your Swift package, you should include a `.swift-build-linux` or `.swift-build-macOS` file in the root level of your repository and specify in it the exact compilation command for the corresponding platform.

--- a/build-package.sh
+++ b/build-package.sh
@@ -84,9 +84,18 @@ function sourceScript () {
 #
 if [ -n "${DOCKER_IMAGE}" ]; then
   echo ">> Executing build in Docker container: ${DOCKER_IMAGE}"
+  # Define default env vars to be passed to docker
+  docker_env_vars="--env SWIFT_SNAPSHOT --env KITURA_NIO --env GCD_ASYNCH --env TESTDB_NAME"
+  # Pass additional vars listed by DOCKER_ENVIRONMENT
+  for DOCKER_ENV_VAR in $DOCKER_ENVIRONMENT; do
+    docker_env_vars="$docker_env_vars --env $DOCKER_ENV_VAR"
+  done
+  # Define default packages to install within docker image.
+  # Install additional packages listed by DOCKER_PACKAGES
+  docker_pkg_list="git sudo lsb-release wget libxml2 pkg-config libpq-dev $DOCKER_PACKAGES"
   set -x
   docker pull ${DOCKER_IMAGE}
-  docker run --env SWIFT_SNAPSHOT --env KITURA_NIO --env GCD_ASYNCH --env TESTDB_NAME -v ${projectBuildDir}:${projectBuildDir} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y git sudo lsb-release wget libxml2 pkg-config libpq-dev && cd $projectBuildDir && ./Package-Builder/build-package.sh ${PACKAGE_BUILDER_ARGS}"
+  docker run ${docker_env_vars} -v ${projectBuildDir}:${projectBuildDir} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y ${docker_pkg_list} && cd $projectBuildDir && ./Package-Builder/build-package.sh ${PACKAGE_BUILDER_ARGS}"
   set +x
   DOCKER_RC=$?
   echo ">> Docker execution complete, RC=${DOCKER_RC}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Builds on #149,  adding the ability to customize the Docker environment by setting `DOCKER_ENVIRONMENT` and `DOCKER_PACKAGES` environment variables.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some tests - for example Kitura-SMTP - work by defining test credentials in Travis environment variables.  These need to be passed through to the Docker container.  We cannot maintain a hard-coded list of all possible env vars to pass through, so instead these can be named within the Travis for that repo, eg: https://github.com/IBM-Swift/Swift-SMTP/pull/92

Other builds require certain system packages to be installed - for example, https://github.com/IBM-Swift/Swift-Kuery-PostgreSQL requires `libpq-dev`.  Although this was included in the list in #149, it could now be removed and specified only by the few packages that require it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://github.com/IBM-Swift/Swift-SMTP/pull/92 tested this feature: https://travis-ci.org/IBM-Swift/Swift-SMTP/builds/455467238

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
