### PR TITLE
Support the --parallel option for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,11 @@ matrix:
         - DOCKER_IMAGE=ubuntu:14.04 CUSTOM_BUILD_SCRIPT=.build-ubuntu1404 CUSTOM_TEST_SCRIPT=.test-ubuntu1404
       sudo: required
 ```
+#### Custom `swift test` arguments
+If you only need to provide arguments to the `swift test` command, rather than providing a customized test script, you can define the `SWIFT_TEST_ARGS` environment variable. For example:
+```
+SWIFT_TEST_ARGS="--parallel --num-workers=16"
+```
 
 ### Custom configuration for executing tests
 Sometimes, a dependency must be set up before the testing process can begin. You may also have the need to execute certain actions after your tests have completed (e.g. shutting down a server). Package-Builder provides an extension point to do this; you can include a `before_tests.sh` and/or a `after_tests.sh` file containing the commands to be executed before and after the tests.

--- a/build-package.sh
+++ b/build-package.sh
@@ -94,7 +94,7 @@ if [ -n "${DOCKER_IMAGE}" ]; then
     docker_run_privileged="--privileged"
   fi
   # Define list of env vars to be passed to docker.
-  docker_env_vars="--env SWIFT_SNAPSHOT --env KITURA_NIO"
+  docker_env_vars="--env SWIFT_SNAPSHOT --env KITURA_NIO --env CUSTOM_BUILD_SCRIPT --env CUSTOM_TEST_SCRIPT --env SWIFT_TEST_ARGS"
   # Pass additional vars listed by DOCKER_ENVIRONMENT
   for DOCKER_ENV_VAR in $DOCKER_ENVIRONMENT; do
     docker_env_vars="$docker_env_vars --env $DOCKER_ENV_VAR"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -27,10 +27,9 @@ elif [ -e ${projectFolder}/.swift-test-macOS ] && [ "$osName" == "osx" ]; then
 elif [ -e ${projectFolder}/.swift-test-linux ] && [ "$osName" == "linux" ]; then
   echo ">> Running custom Linux test command: $(cat ${projectFolder}/.swift-test-linux)"
   source ${projectFolder}/.swift-test-linux
-elif [ -n "${RUN_TESTS_PARALLEL}"]; then
-  swift test --parallel
 else
-  swift test
+  echo ">> Running test command: swift test ${SWIFT_TEST_ARGS}"
+  swift test ${SWIFT_TEST_ARGS}
 fi
 TEST_EXIT_CODE=$?
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -27,6 +27,8 @@ elif [ -e ${projectFolder}/.swift-test-macOS ] && [ "$osName" == "osx" ]; then
 elif [ -e ${projectFolder}/.swift-test-linux ] && [ "$osName" == "linux" ]; then
   echo ">> Running custom Linux test command: $(cat ${projectFolder}/.swift-test-linux)"
   source ${projectFolder}/.swift-test-linux
+elif [ -n "${RUN_TESTS_PARALLEL}"]; then
+  swift test --parallel
 else
   swift test
 fi


### PR DESCRIPTION
Currently to run tests in parallel (`swift test --parallel`) one needs to use the `CUSTOM_TEST_SCRIPT` env var and maintain a separate script file. We could instead support `--parallel` via an env var `RUN_TESTS_PARALLEL` only.