### PR TITLE
macOS: remove the default libressl installation

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -128,13 +128,7 @@ export projectFolder=`pwd`
 projectName="$(basename $projectFolder)"
 echo ">> projectName: $projectName"
 
-# Install libressl on osx
 if [ "${osName}" == "osx" ]; then
-  echo ">> Installing libressl..."
-  brew update
-  brew install libressl
-  echo ">> Finished installing libressl."
-
   if [ -n "${SONARCLOUD_ELIGIBLE}" ]; then
     echo ">> Installing sonar-scanner..."
     brew install sonar-scanner


### PR DESCRIPTION
It has been observed that libressl installation takes 4-5 minutes. This is affecting the build times of all IBM-Swift repos, even those that don't need libressl. This commit removes the default installation and delegates that responsibility to the repositories that actually need libressl (e.g. Kitura-NIO).