### PR TITLE
macOS: use an enviornment variable to list brew packages to install

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -129,6 +129,16 @@ projectName="$(basename $projectFolder)"
 echo ">> projectName: $projectName"
 
 if [ "${osName}" == "osx" ]; then
+  # BREW_INSTALL_PACKAGES is expected to have a whitespace-separated list of all packages that need to be installed
+  if [ -n "${BREW_INSTALL_PACKAGES}" ]; then
+    brew update
+    for PACKAGE in ${BREW_INSTALL_PACKAGES}; do
+      echo ">> Installing ${PACKAGE}..."
+      brew install ${PACKAGE}
+      echo ">> Finished installing ${PACKAGE}."
+    done
+  fi
+
   if [ -n "${SONARCLOUD_ELIGIBLE}" ]; then
     echo ">> Installing sonar-scanner..."
     brew install sonar-scanner


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Pick up brew packages to install from an environment variable

## Description
Instead of installing brew packages by default, or having them installed in the .travis.yml files of individual repos, it may help introducing an environment variable called `BREW_INSTALL_PACKAGES` to provide a space-separated list of all necessary packages necessary packages. Apologies for #156.

## Motivation and Context
Installing brew packages like libressl by default increases the build times considerably.