### PR TITLE
Only use brew if dependencies are required

### DIFF
--- a/osx/install_swift_binaries.sh
+++ b/osx/install_swift_binaries.sh
@@ -29,10 +29,12 @@ echo ">> Running ${BASH_SOURCE[0]}"
 # Install Swift binaries
 # See http://apple.stackexchange.com/questions/72226/installing-pkg-with-terminal
 
-# Install macOS system level dependencies
-brew update > /dev/null
-#brew install curl
-brew install wget > /dev/null || brew outdated wget > /dev/null || brew upgrade wget > /dev/null
+# Install macOS system level dependencies if required
+if [ ! -x "`which wget`" ]; then
+  brew update > /dev/null
+  #brew install curl
+  brew install wget > /dev/null || brew outdated wget > /dev/null || brew upgrade wget > /dev/null
+fi
 
 #Download and install Swift
 echo "Swift installed $SWIFT_PREINSTALL does not match snapshot $SWIFT_SNAPSHOT."


### PR DESCRIPTION
Mac builds require `wget` to pull builds from swift.org.  Currently, we always perform a `brew update` and then attempt a `brew install wget` (or upgrade, if it's already installed).

This is unnecessary as Travis images already have wget installed, and adds extra time to Mac builds that need to download a Swift binary.