### PR TITLE
Support for running Kitura tests, while building Kitura-net/Kitua-NIO

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -54,4 +54,33 @@ if [[ $TEST_EXIT_CODE != 0 ]]; then
     exit $TEST_EXIT_CODE
 fi
 
+# Run Kitura tests with the current Kitura-net or Kitura-NIO branch, if asked for
+if [ -n "${RUN_KITURA_TESTS}" ]; then
+    PROJECT_DIR=`pwd`
+
+    # If we are to test Kitura with Kitura-NIO, we'd need to set the KITURA_NIO env var
+    NET_PACKAGE=$(pwd | rev | cut -d'/' -f1 | rev)
+    if [ "${NET_PACKAGE}" == "Kitura-NIO" ]; then
+        echo ">> Setting KITURA_NIO=1"
+        export KITURA_NIO=1
+    fi
+    echo ">> cd ../ && git clone https://github.com/IBM-Swift/Kitura && cd Kitura"
+    cd ../ && git clone https://github.com/IBM-Swift/Kitura && cd Kitura
+    echo ">> swift build"
+    swift build
+    echo ">> swift package edit $NET_PACKAGE --path $PROJECT_DIR"
+    swift package edit $NET_PACKAGE --path $PROJECT_DIR
+    echo ">> swift package edit returned $?"
+    echo ">> swift test"
+    swift test
+    TEST_EXIT_CODE=$?
+
+    if [[ $TEST_EXIT_CODE != 0 ]]; then
+        exit $TEST_EXIT_CODE
+    fi
+
+    # On macOS, swiftlint will run after this script. We make sure we exit this script from the right location
+    cd $PROJECT_DIR 
+fi
+
 set -e


### PR DESCRIPTION
Support for running Kitura tests in Travis, while building Kitura-net/Kitua-NIO

## Description
Kitura tests could be run on every pull request raised against the Kitura-net and Kitura-NIO repositories on Travis. If the base build (Kitura-net/Kitura-NIO) passes, we simply clone Kitura, edit the package to point to the current Kitura-net/Kitura-NIO branch and run the Kitura tests.

## Motivation and Context
The Kitura-net and Kitura-NIO test suites aren't as effective as the Kitura test suite itself, in catching regressive patches. It is essential to have the Kitura tests run on every pull request raised on both of these networking library repositories. 

The issue opened for this is #159.

## How Has This Been Tested?
1. [Kitura-NIO PR ](https://github.com/IBM-Swift/Kitura-NIO/pull/157) that uses RUN_KITURA_TESTS on a few builds.
2. [Dummy Kitura-NIO PR](https://github.com/IBM-Swift/Kitura-NIO/pull/158) that has an intentional bug. This goes through the Kitura-NIO tests but fails while running Kitura tests.
3. [Kitura-net PR](https://github.com/IBM-Swift/Kitura-net/pull/288) that uses RUN_KITURA_TESTS.
4. [Dummy Kitura-net PR](
https://github.com/IBM-Swift/Kitura-net/pull/289) that has an intentional bug - Kitura-net tests get through, but Kitura tests fail.

Please see the related travis CI jobs to verify the working of this patch.