### PR TITLE
Enable Travis folding of build output

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -210,7 +210,7 @@ fi
 
 # Execute test cases
 if [ -e "${projectFolder}/Tests" ]; then
-    travis_fold start "swift_test"
+    travis_fold start "swift_pre_test"
     travis_time_start
     echo ">> Testing Swift package..."
     # Execute OS specific pre-test steps
@@ -218,9 +218,13 @@ if [ -e "${projectFolder}/Tests" ]; then
 
     # Execute common pre-test steps
     sourceScript "`find ${projectFolder} -path "*/${projectName}/common/before_tests.sh" -not -path "*/Package-Builder/*" -not -path "*/Packages/*"`" "common pre-tests steps"
+    travis_time_finish
+    travis_fold end "swift_pre_test"
 
     source ${SCRIPT_DIR}/run_tests.sh
 
+    travis_fold start "swift_post_test"
+    travis_time_start
     # Execute common post-test steps
     sourceScript "`find ${projectFolder} -path "*/${projectName}/common/after_tests.sh" -not -path "*/Package-Builder/*" -not -path "*/Packages/*"`" "common post-tests steps"
 
@@ -230,7 +234,7 @@ if [ -e "${projectFolder}/Tests" ]; then
     echo ">> Finished testing Swift package."
     echo
     travis_time_finish
-    travis_fold end "swift_test"
+    travis_fold end "swift_post_test"
 else
     echo ">> No test cases found."
 fi

--- a/build-package.sh
+++ b/build-package.sh
@@ -278,11 +278,13 @@ fi
 # Generate test code coverage report (macOS). The Travis build must have the
 # SONARCLOUD_ELIGIBLE environment variable defined.
 if [ "$(uname)" == "Darwin" -a -n "${SONARCLOUD_ELIGIBLE}" ]; then
+  travis_start "swift_sonarcloud"
   if [ -e ${projectFolder}/.swift-sonarcloud ]; then
       source ${projectFolder}/.swift-sonarcloud
   else
       sourceScript "${SCRIPT_DIR}/sonarcloud.sh" "sonarcloud generation"
   fi
+  travis_end
 fi
 
 # Generate jazzy docs (macOS) for Pull Requests that have the 'jazzy-doc' label.

--- a/build-package.sh
+++ b/build-package.sh
@@ -63,6 +63,14 @@ fi
 # Ref: https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# Import local copy of Travis timing / folding functions (this enables us to
+# produce Travis folded output from within a Docker container)
+# Source: https://github.com/travis-ci/travis-build/tree/master/lib/travis/build/bash
+source ${SCRIPT_DIR}/lib/travis_fold.bash
+source ${SCRIPT_DIR}/lib/travis_nanoseconds.bash
+source ${SCRIPT_DIR}/lib/travis_time_start.bash
+source ${SCRIPT_DIR}/lib/travis_time_finish.bash
+
 # Utility functions
 function sourceScript () {
   if [ -e "$1" ]; then

--- a/build-package.sh
+++ b/build-package.sh
@@ -167,6 +167,7 @@ echo
 
 # Build swift package
 travis_fold start "swift_build"
+travis_time_start
 echo ">> Building Swift package..."
 
 cd ${projectFolder}
@@ -185,6 +186,7 @@ else
 fi
 
 echo ">> Finished building Swift package."
+travis_time_finish
 travis_fold end "swift_build"
 
 # Copy test credentials for project if available
@@ -201,6 +203,7 @@ fi
 # Execute test cases
 if [ -e "${projectFolder}/Tests" ]; then
     travis_fold start "swift_test"
+    travis_time_start
     echo ">> Testing Swift package..."
     # Execute OS specific pre-test steps
     sourceScript "`find ${projectFolder} -path "*/${projectName}/${osName}/before_tests.sh" -not -path "*/Package-Builder/*" -not -path "*/Packages/*"`" "${osName} pre-tests steps"
@@ -218,6 +221,7 @@ if [ -e "${projectFolder}/Tests" ]; then
 
     echo ">> Finished testing Swift package."
     echo
+    travis_time_finish
     travis_fold end "swift_test"
 else
     echo ">> No test cases found."
@@ -237,9 +241,11 @@ if [ "$(uname)" == "Darwin" ]; then
 
     # Print linter version
     travis_fold start "swift_lint"
+    travis_time_start
     echo "Running linter swiftlint version $(swiftlint version)"
 
     swiftlint lint --quiet --config ${projectFolder}/.swiftlint.yml
+    travis_time_finish
     travis_fold end "swift_lint"
   #else
   #swiftlint lint --quiet --config ${projectFolder}/Package-Builder/.swiftlint.yml
@@ -251,11 +257,13 @@ fi
 # CODECOV_ELIGIBLE environment variable defined.
 if [ "$(uname)" == "Darwin" -a -n "${CODECOV_ELIGIBLE}" ]; then
   travis_fold start "swift_codecov"
+  travis_time_start
   if [ -e ${projectFolder}/.swift-codecov ]; then
       source ${projectFolder}/.swift-codecov
   else
       sourceScript "${SCRIPT_DIR}/codecov.sh" "codecov generation"
   fi
+  travis_time_finish
   travis_fold end "swift_codecov"
 fi
 
@@ -295,8 +303,10 @@ if [ "$(uname)" == "Darwin" -a "${TRAVIS_PULL_REQUEST}" != "false" -a -n "${JAZZ
         # Check if any of the labels contain the text 'jazzy-doc'
         if [[ $candidateTags == *"jazzy-doc"* ]]; then
             travis_fold start "jazzy_doc"
+            travis_time_start
             echo "Documentation tag jazzy-doc exists for this repo"
             sourceScript "${SCRIPT_DIR}/jazzy.sh" "jazzy-doc generation"
+            travis_time_finish
             travis_fold end "jazzy_doc"
         else
             echo "Note: No jazzy-doc tag found."

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,1 @@
+This directory includes Travis functions sourced from: https://github.com/travis-ci/travis-build/tree/master/lib/travis/build/bash

--- a/lib/travis_fold.bash
+++ b/lib/travis_fold.bash
@@ -1,0 +1,5 @@
+travis_fold() {
+  local action="${1}"
+  local name="${2}"
+  echo -en "travis_fold:${action}:${name}\\r${ANSI_CLEAR}"
+}

--- a/lib/travis_nanoseconds.bash
+++ b/lib/travis_nanoseconds.bash
@@ -1,0 +1,12 @@
+travis_nanoseconds() {
+  local cmd='date'
+  local format='+%s%N'
+
+  if hash gdate >/dev/null 2>&1; then
+    cmd='gdate'
+  elif [[ "${TRAVIS_OS_NAME}" == osx ]]; then
+    format='+%s000000000'
+  fi
+
+  "${cmd}" -u "${format}"
+}

--- a/lib/travis_time_finish.bash
+++ b/lib/travis_time_finish.bash
@@ -1,0 +1,9 @@
+travis_time_finish() {
+  local result="${?}"
+  local travis_timer_end_time
+  travis_timer_end_time="$(travis_nanoseconds)"
+  local duration
+  duration="$((travis_timer_end_time - TRAVIS_TIMER_START_TIME))"
+  echo -en "travis_time:end:${TRAVIS_TIMER_ID}:start=${TRAVIS_TIMER_START_TIME},finish=${travis_timer_end_time},duration=${duration}\\r${ANSI_CLEAR}"
+  return "${result}"
+}

--- a/lib/travis_time_start.bash
+++ b/lib/travis_time_start.bash
@@ -1,0 +1,6 @@
+travis_time_start() {
+  TRAVIS_TIMER_ID="$(printf %08x $((RANDOM * RANDOM)))"
+  TRAVIS_TIMER_START_TIME="$(travis_nanoseconds)"
+  export TRAVIS_TIMER_ID TRAVIS_TIMER_START_TIME
+  echo -en "travis_time:start:$TRAVIS_TIMER_ID\\r${ANSI_CLEAR}"
+}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -28,8 +28,12 @@ elif [ -e ${projectFolder}/.swift-test-linux ] && [ "$osName" == "linux" ]; then
   echo ">> Running custom Linux test command: $(cat ${projectFolder}/.swift-test-linux)"
   source ${projectFolder}/.swift-test-linux
 else
+  travis_fold start "swift_test"
+  travis_time_start
   echo ">> Running test command: swift test ${SWIFT_TEST_ARGS}"
   swift test ${SWIFT_TEST_ARGS}
+  travis_time_finish
+  travis_fold end "swift_test"
 fi
 TEST_EXIT_CODE=$?
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -33,7 +33,9 @@ else
   travis_start "swift_test"
   echo ">> Running test command: swift test ${SWIFT_TEST_ARGS}"
   swift test ${SWIFT_TEST_ARGS}
+  SWIFT_TEST_STATUS=$?
   travis_end
+  (exit $SWIFT_TEST_STATUS)   # Ensure TEST_EXIT_CODE reflects swift test, not travis_end!
 fi
 TEST_EXIT_CODE=$?
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -22,19 +22,13 @@ ulimit -c unlimited      # enable core file generation
 # implemented from within the custom script itself.
 if [ -n "${CUSTOM_TEST_SCRIPT}" ] && [ -e ${projectFolder}/$CUSTOM_TEST_SCRIPT ]; then
   echo ">> Running custom test command: $CUSTOM_TEST_SCRIPT"
-  set -x
   source ${projectFolder}/$CUSTOM_TEST_SCRIPT
-  set +x
 elif [ -e ${projectFolder}/.swift-test-macOS ] && [ "$osName" == "osx" ]; then
   echo ">> Running custom macOS test command: ${projectFolder}/.swift-test-macOS"
-  set -x
   source ${projectFolder}/.swift-test-macOS
-  set +x 
 elif [ -e ${projectFolder}/.swift-test-linux ] && [ "$osName" == "linux" ]; then
   echo ">> Running custom Linux test command: ${projectFolder}/.swift-test-linux"
-  set -x
   source ${projectFolder}/.swift-test-linux
-  set +x
 else
   travis_start "swift_test"
   echo ">> Running test command: swift test ${SWIFT_TEST_ARGS}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some of the IBM-Swift build logs are enormous, and can be difficult to dig through when debugging a build failure/timeout, or just to figure out which part of the build is taking so long.

Travis has some (undocumented) support for 'folding' sections of logs, which can optionally be timed, which produces a much more consumable build log.  This PR adds these Travis functions, and applies them to `build-package.sh` and `run_tests.sh`.

In addition, custom test scripts may wish to subdivide their own output into further sections, for example when Kitura-NIO runs its own tests, then builds and runs the Kitura tests.  An example of this PR applied to such an arrangement is here:
https://travis-ci.org/djones6/Kitura-NIO/jobs/489546292

In order to allow Package-Builder to call these functions, it was necessary to duplicate their code into `lib/`.  While it is possible to export these Travis functions into our script, this would require changes to every .travis.yml that uses Package-Builder which seems a bit of a non-starter, plus there's no way to pass an exported function through to Docker's shell, as far as I can tell.