### PR TITLE
Remove dependency on lsb-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,17 +23,17 @@ matrix:
       dist: trusty
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=4.2.1
+      env: DOCKER_IMAGE=swift:4.2.2 SWIFT_SNAPSHOT=4.2.2
     - os: linux
       dist: trusty
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=ubuntu:16.04 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+      env: DOCKER_IMAGE=swift:4.2.2 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
     - os: linux
       dist: trusty
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=ubuntu:18.04 SWIFT_SNAPSHOT=4.2.1
+      env: DOCKER_IMAGE=ubuntu:18.04 SWIFT_SNAPSHOT=4.2.2
     - os: osx
       osx_image: xcode9.2
       sudo: required
@@ -46,7 +46,7 @@ matrix:
     - os: osx
       osx_image: xcode10.1
       sudo: required
-      env: SWIFT_SNAPSHOT=4.2.1
+      env: SWIFT_SNAPSHOT=4.2.2
     - os: osx
       osx_image: xcode10.1
       sudo: required

--- a/build-package.sh
+++ b/build-package.sh
@@ -101,7 +101,7 @@ function travis_end () {
 # Additional env vars can be passed by listing them in DOCKER_ENVIRONMENT.
 #
 # Within the Docker image, we will install some default system packages:
-# - git, sudo, lsb-release and wget are required by Package-Builder itself.
+# - git, sudo and wget are required by Package-Builder itself.
 # - pkg-config is required by SwiftPM to locate .pc files (see https://github.com/apple/swift-package-manager/pull/338).
 #
 # Additional packages can be installed by listing them in DOCKER_PACKAGES.
@@ -119,7 +119,7 @@ if [ -n "${DOCKER_IMAGE}" ]; then
     docker_env_vars="$docker_env_vars --env $DOCKER_ENV_VAR"
   done
   # Define list of packages to install within docker image.
-  docker_pkg_list="git sudo lsb-release wget pkg-config $DOCKER_PACKAGES"
+  docker_pkg_list="git sudo wget pkg-config $DOCKER_PACKAGES"
   set -x
   docker pull ${DOCKER_IMAGE}
   # Invoke Package-Builder within the Docker image.

--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -34,10 +34,12 @@ export DEBIAN_FRONTEND="noninteractive"
 sudo -E apt-get -q update
 sudo -E apt-get -y -q install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata libz-dev libblocksruntime-dev
 
-# Environment vars
-version=`lsb_release -d | awk '{print tolower($2) $3}'`
-export UBUNTU_VERSION=`echo $version | awk -F. '{print $1"."$2}'`
-export UBUNTU_VERSION_NO_DOTS=`echo $version | awk -F. '{print $1$2}'`
+# Get the ID and VERSION_ID from /etc/os-release, stripping quotes
+distribution=`grep '^ID=' /etc/os-release | sed -e's#.*="\?\([^"]*\)"\?#\1#'`
+version=`grep '^VERSION_ID=' /etc/os-release | sed -e's#.*="\?\([^"]*\)"\?#\1#'`
+version_no_dots=`echo $version | awk -F. '{print $1$2}'`
+export UBUNTU_VERSION="${distribution}${version}"
+export UBUNTU_VERSION_NO_DOTS="${distribution}${version_no_dots}"
 
 echo ">> Installing '${SWIFT_SNAPSHOT}'..."
 # Install Swift compiler


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Package-Builder currently has to install the lsb-release package for Docker builds, but only uses it to derive the Ubuntu release name and version in order to install Swift.

That same information is available in all modern distributions in `/etc/os-release`, so there is no need for this tool, and we can save build time by not installing it (or its many dependencies).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
