### PR TITLE
Add Kitura-specific system packages to Docker list

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -119,7 +119,7 @@ if [ -n "${DOCKER_IMAGE}" ]; then
     docker_env_vars="$docker_env_vars --env $DOCKER_ENV_VAR"
   done
   # Define list of packages to install within docker image.
-  docker_pkg_list="git sudo wget pkg-config $DOCKER_PACKAGES"
+  docker_pkg_list="git sudo wget pkg-config libcurl4-openssl-dev libssl-dev $DOCKER_PACKAGES"
   set -x
   docker pull ${DOCKER_IMAGE}
   # Invoke Package-Builder within the Docker image.


### PR DESCRIPTION
Currently, the official Swift Docker images include `libcurl4-openssl-dev` and `libssl-dev`. However, in https://github.com/apple/swift-docker/pull/135 we have optimised the Swift 5 Docker images, removing these packages, and these changes will be pushed to Docker Hub soon.

Because Kitura requires these packages to build Kitura-net let's proactively add them to the list of packages we install in our CI. This should avoid any breakage.