### PR TITLE
Install specific dependencies for Swift based on version

### DIFF
--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -31,8 +31,48 @@ echo ">> Running ${BASH_SOURCE[0]}"
 # Suppress prompts of any kind while executing apt-get
 export DEBIAN_FRONTEND="noninteractive"
 
+# Find the first numeric value in the swift version string. For example:
+# swift-5.0-DEVELOPMENT-SNAPSHOT-1234-56-78-a  -> 5
+# 4.0.3 -> 4
+swiftMajor=`echo $SWIFT_SNAPSHOT | sed -e's#[^0-9]*\([0-9]\).*#\1#'`
+
+# Install prerequisites for this version of Swift
 sudo -E apt-get -q update
-sudo -E apt-get -y -q install clang lldb-3.8 libicu-dev libtool libcurl4-openssl-dev libbsd-dev build-essential libssl-dev uuid-dev tzdata libz-dev libblocksruntime-dev
+case $swiftMajor in
+3|4)
+  sudo -E apt-get -y -q install \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    clang \
+    lldb-3.8 \
+    libicu-dev \
+    libtool \
+    libbsd-dev \
+    build-essential \
+    uuid-dev \
+    tzdata \
+    libz-dev \
+    libblocksruntime-dev
+  ;;
+*)
+  sudo -E apt-get -y -q install \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libatomic1 \
+    libbsd0 \
+    libcurl4 \
+    libxml2 \
+    libedit2 \
+    libsqlite3-0 \
+    libc6-dev \
+    binutils \
+    libgcc-5-dev \
+    libstdc++-5-dev \
+    libpython2.7 \
+    tzdata \
+    pkg-config
+  ;;
+esac
 
 # Get the ID and VERSION_ID from /etc/os-release, stripping quotes
 distribution=`grep '^ID=' /etc/os-release | sed -e's#.*="\?\([^"]*\)"\?#\1#'`

--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -36,6 +36,24 @@ export DEBIAN_FRONTEND="noninteractive"
 # 4.0.3 -> 4
 swiftMajor=`echo $SWIFT_SNAPSHOT | sed -e's#[^0-9]*\([0-9]\).*#\1#'`
 
+# Get the Ubuntu ID and VERSION_ID from /etc/os-release, stripping quotes
+distribution=`grep '^ID=' /etc/os-release | sed -e's#.*="\?\([^"]*\)"\?#\1#'`
+version=`grep '^VERSION_ID=' /etc/os-release | sed -e's#.*="\?\([^"]*\)"\?#\1#'`
+version_no_dots=`echo $version | awk -F. '{print $1$2}'`
+versionMajor=`echo $version | awk -F. '{print $1}'`
+export UBUNTU_VERSION="${distribution}${version}"
+export UBUNTU_VERSION_NO_DOTS="${distribution}${version_no_dots}"
+
+# Customize package dependencies based on Ubuntu version
+case $versionMajor in
+14|15|16|17)
+  libCurlPackage="libcurl3"
+  ;;
+*)
+  libCurlPackage="libcurl4"
+  ;;
+esac
+
 # Install prerequisites for this version of Swift
 sudo -E apt-get -q update
 case $swiftMajor in
@@ -60,7 +78,7 @@ case $swiftMajor in
     libssl-dev \
     libatomic1 \
     libbsd0 \
-    libcurl4 \
+    ${libCurlPackage} \
     libxml2 \
     libedit2 \
     libsqlite3-0 \
@@ -73,13 +91,6 @@ case $swiftMajor in
     pkg-config
   ;;
 esac
-
-# Get the ID and VERSION_ID from /etc/os-release, stripping quotes
-distribution=`grep '^ID=' /etc/os-release | sed -e's#.*="\?\([^"]*\)"\?#\1#'`
-version=`grep '^VERSION_ID=' /etc/os-release | sed -e's#.*="\?\([^"]*\)"\?#\1#'`
-version_no_dots=`echo $version | awk -F. '{print $1$2}'`
-export UBUNTU_VERSION="${distribution}${version}"
-export UBUNTU_VERSION_NO_DOTS="${distribution}${version_no_dots}"
 
 echo ">> Installing '${SWIFT_SNAPSHOT}'..."
 # Install Swift compiler


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates `linux/install-swift-binaries.sh` to install a more appropriate set of dependencies for Swift 5 or newer.  The list of dependencies is based on the [swift:5.0.1 Dockerfile](https://github.com/apple/swift-docker/blob/0aafffef619fb3b1824c968cbbe2fba4ba41bd26/5.0/ubuntu/18.04/Dockerfile).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Swift 5.0.1 Docker images contain a problem which prevents `python-2.7` from installing, leading to [CI failures since the 5.0.1 image was published](https://travis-ci.org/IBM-Swift/Kitura/builds/524106839).  This is a prereq of `clang`, but Swift 5 doesn't need clang to be installed anymore, and so we can avoid this problem by installing a more appropriate set.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
