### PR TITLE
Workaround for SR-10591

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -122,7 +122,7 @@ if [ -n "${DOCKER_IMAGE}" ]; then
   docker_pkg_list="git sudo wget pkg-config libcurl4-openssl-dev libssl-dev $DOCKER_PACKAGES"
   # Temporary fix for Swift 5.0.1 images that ship Python modules in a conflicting directory
   # See: https://bugs.swift.org/browse/SR-10591
-  docker_python_fix="mv /usr/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages && rmdir /usr/lib/python2.7/site-packages && ln -s dist-packages /usr/lib/python2.7/site-packages"
+  docker_python_fix="if [ -d "/usr/lib/python2.7/site-packages" ]; then mv /usr/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages && rmdir /usr/lib/python2.7/site-packages && ln -s dist-packages /usr/lib/python2.7/site-packages ; fi"
   set -x
   docker pull ${DOCKER_IMAGE}
   # Invoke Package-Builder within the Docker image.

--- a/build-package.sh
+++ b/build-package.sh
@@ -120,10 +120,13 @@ if [ -n "${DOCKER_IMAGE}" ]; then
   done
   # Define list of packages to install within docker image.
   docker_pkg_list="git sudo wget pkg-config libcurl4-openssl-dev libssl-dev $DOCKER_PACKAGES"
+  # Temporary fix for Swift 5.0.1 images that ship Python modules in a conflicting directory
+  # See: https://bugs.swift.org/browse/SR-10591
+  docker_python_fix="mv /usr/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages && rmdir /usr/lib/python2.7/site-packages && ln -s dist-packages /usr/lib/python2.7/site-packages"
   set -x
   docker pull ${DOCKER_IMAGE}
   # Invoke Package-Builder within the Docker image.
-  docker run ${docker_run_privileged} ${docker_env_vars} -v ${projectBuildDir}:${projectBuildDir} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y ${docker_pkg_list} && cd $projectBuildDir && ./Package-Builder/build-package.sh ${PACKAGE_BUILDER_ARGS}"
+  docker run ${docker_run_privileged} ${docker_env_vars} -v ${projectBuildDir}:${projectBuildDir} ${DOCKER_IMAGE} /bin/bash -c "$docker_python_fix && apt-get update && apt-get install -y ${docker_pkg_list} && cd $projectBuildDir && ./Package-Builder/build-package.sh ${PACKAGE_BUILDER_ARGS}"
   set +x
   DOCKER_RC=$?
   echo ">> Docker execution complete, RC=${DOCKER_RC}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Moves some Python modules from `/usr/lib/python2.7/site-packages/` to `dist-packages/`, and makes the former a symlink to the latter.  This allows Python to be installed in swift:5.0.1 Docker images.

This is done conditionally on the existence of `/usr/lib/python2.7/site-packages`, since base Ubuntu images do not have Python installed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a workaround for https://bugs.swift.org/browse/SR-10591

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build failing (needing this fix): https://travis-ci.org/IBM-Swift/Kitura-WebSocket-NIO/builds/526849286
Build using this branch: https://travis-ci.org/IBM-Swift/Kitura-WebSocket-NIO/builds/526853352

I've tested that this fix works for both the base Ubuntu and Swift docker images.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
