### PR TITLE
Support Swift 5 on Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,19 @@ matrix:
       services: docker
       env: DOCKER_IMAGE=swift:4.2.4 SWIFT_SNAPSHOT=4.2.4
     - os: linux
-      dist: xenial
+      dist: trusty
       sudo: required
-      services: docker
-      env: DOCKER_IMAGE=swift:5.0-xenial SWIFT_SNAPSHOT=5.0
+      env: DOCKER_IMAGE=ubuntu:14.04 SWIFT_SNAPSHOT=5.0.1
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=swift:5.0 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+      env: DOCKER_IMAGE=swift:5.0.1-xenial SWIFT_SNAPSHOT=5.0.1
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE=swift:5.0.1 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
     - os: osx
       osx_image: xcode9.2
       sudo: required
@@ -50,7 +54,7 @@ matrix:
     - os: osx
       osx_image: xcode10.2
       sudo: required
-      env: SWIFT_SNAPSHOT=5.0
+      env: SWIFT_SNAPSHOT=5.0.1
     - os: osx
       osx_image: xcode10.2
       sudo: required

--- a/linux/install_swift_binaries.sh
+++ b/linux/install_swift_binaries.sh
@@ -46,11 +46,17 @@ export UBUNTU_VERSION_NO_DOTS="${distribution}${version_no_dots}"
 
 # Customize package dependencies based on Ubuntu version
 case $versionMajor in
-14|15|16|17)
+14)
   libCurlPackage="libcurl3"
+  gccPackageVersion="4.8"
+  ;;
+15|16|17)
+  libCurlPackage="libcurl3"
+  gccPackageVersion="5"
   ;;
 *)
   libCurlPackage="libcurl4"
+  gccPackageVersion="5"
   ;;
 esac
 
@@ -84,8 +90,8 @@ case $swiftMajor in
     libsqlite3-0 \
     libc6-dev \
     binutils \
-    libgcc-5-dev \
-    libstdc++-5-dev \
+    libgcc-${gccPackageVersion}-dev \
+    libstdc++-${gccPackageVersion}-dev \
     libpython2.7 \
     tzdata \
     pkg-config


### PR DESCRIPTION
It is still possible to use Ubuntu 14.04 and Swift 5.0 since builds were produced - at the moment the selection of packages introduced in #165 fails with this permutation as gcc-5.0 is not available (we need 4.8 instead).  This adds handling for this case, and a Travis build.