### PR TITLE
Update to jazzy 0.9.6 for Swift 5 support

### DIFF
--- a/jazzy.sh
+++ b/jazzy.sh
@@ -63,8 +63,9 @@ if [[ "${LATEST_COMMIT_MESSAGE}" =~ "[jazzy-doc]" ]]; then
     exit 0
 fi
 
-# Install jazzy (version set to 0.9.1 until https://github.com/realm/jazzy/issues/972 is fixed)
-sudo gem install jazzy -v 0.9.1
+# Install a specific version of jazzy (0.9.6 supports Swift 5). Future versions may also be fine,
+# but their output should be checked before upgrading.
+sudo gem install jazzy -v 0.9.6
 # Generate xcode project
 sourceScript "${SCRIPT_DIR}/generate-xcodeproj.sh" "xcodeproj generation"
 # Run jazzy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The Jazzy issue that meant we had to remain on version 0.9.1 received a workaround in 0.9.3, and additionally, a fix for the underlying issue was delivered in Swift 5.

This PR updates to Jazzy 0.9.6, which fixes some issues when running on a Swift 5 project (erroneously generating docs for `deinit { }` blocks for example).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested here: https://github.com/IBM-Swift/Kitura/pull/1451

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
