### PR TITLE
Upgrade libseccomp before running within Docker

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -123,6 +123,10 @@ if [ -n "${DOCKER_IMAGE}" ]; then
   # Temporary fix for Swift 5.0.1 images that ship Python modules in a conflicting directory
   # See: https://bugs.swift.org/browse/SR-10591
   docker_python_fix="if [ -d "/usr/lib/python2.7/site-packages" ]; then mv /usr/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages && rmdir /usr/lib/python2.7/site-packages && ln -s dist-packages /usr/lib/python2.7/site-packages ; fi"
+  # Update libseccomp2 to ensure statx is whitelisted.
+  travis_start "upgrade_libseccomp2"
+  sudo apt-get update && sudo apt-get install -y libseccomp2
+  travis_end
   set -x
   docker pull ${DOCKER_IMAGE}
   # Invoke Package-Builder within the Docker image.

--- a/build-package.sh
+++ b/build-package.sh
@@ -137,11 +137,14 @@ if [ -n "${DOCKER_IMAGE}" ]; then
   set -x
   docker run ${docker_run_privileged} ${docker_env_vars} -v ${projectBuildDir}:${projectBuildDir} --name packagebuildercontainer ${DOCKER_IMAGE} /bin/bash -c "$docker_python_fix && apt-get update && apt-get install -y ${docker_pkg_list}"
   docker commit packagebuildercontainer packagebuilderimage
+  docker container rm packagebuildercontainer
   set +x
   travis_end
   # Run Package-Builder within the new image.
   set -x
-  docker run -v ${projectBuildDir}:${projectBuildDir} packagebuilderimage /bin/bash -c "cd $projectBuildDir && ./Package-Builder/build-package.sh ${PACKAGE_BUILDER_ARGS}"
+  docker run -v ${projectBuildDir}:${projectBuildDir} --name packagebuilderrun packagebuilderimage /bin/bash -c "cd $projectBuildDir && ./Package-Builder/build-package.sh ${PACKAGE_BUILDER_ARGS}"
+  docker container rm packagebuilderrun
+  docker image rm packagebuilderimage
   set +x
   DOCKER_RC=$?
   echo ">> Docker execution complete, RC=${DOCKER_RC}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Upgrades the `libseccomp2` package on the system if we're about to run inside Docker.

Also adds some additional travis_folds to quieten some of the output.  I split the `docker run` process into two for this purpose (setting up of the docker container with dependencies, vs executing Package-Builder within it).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/IBM-Swift/Kitura/pull/1466 uncovered a problem when trying to run the latest Swift 5.1 snapshots inside a Docker container.

As Foundation now uses the `statx` syscall, this fails when running on Travis, because the version of the `libseccomp2` package that comes as standard with Ubuntu 16.04 is sufficiently old that this (relatively recent) syscall is not whitelisted, and it fails when issued from within Docker.  This causes SwiftPM to believe that the `swiftc` executable cannot be found, when in reality FileManager couldn't get the file attributes using this new method.

Foundation should be fixed to handle this case and fall back to the old method (as it will if `statx` isn't available on the current kernel), but in the meantime we can work around this by simply upgrading the version of libseccomp2.  The whitelisting also applies to Docker as well, though Travis already supplies a sufficiently recent Docker version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested via: https://github.com/IBM-Swift/Kitura/pull/1466
(see build: https://travis-ci.org/IBM-Swift/Kitura/jobs/550227071)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
