### PR TITLE
Remove workaround for 5.1 Foundation statx issue

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -124,9 +124,9 @@ if [ -n "${DOCKER_IMAGE}" ]; then
   # See: https://bugs.swift.org/browse/SR-10591
   docker_python_fix="if [ -d "/usr/lib/python2.7/site-packages" ]; then mv /usr/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages && rmdir /usr/lib/python2.7/site-packages && ln -s dist-packages /usr/lib/python2.7/site-packages ; fi"
   # Update libseccomp2 to ensure statx is whitelisted.
-  travis_start "upgrade_libseccomp2"
-  sudo apt-get update && sudo apt-get install -y libseccomp2
-  travis_end
+  #travis_start "upgrade_libseccomp2"
+  #sudo apt-get update && sudo apt-get install -y libseccomp2
+  #travis_end
   travis_start "docker_pull"
   docker pull ${DOCKER_IMAGE}
   travis_end

--- a/build-package.sh
+++ b/build-package.sh
@@ -123,10 +123,6 @@ if [ -n "${DOCKER_IMAGE}" ]; then
   # Temporary fix for Swift 5.0.1 images that ship Python modules in a conflicting directory
   # See: https://bugs.swift.org/browse/SR-10591
   docker_python_fix="if [ -d "/usr/lib/python2.7/site-packages" ]; then mv /usr/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages && rmdir /usr/lib/python2.7/site-packages && ln -s dist-packages /usr/lib/python2.7/site-packages ; fi"
-  # Update libseccomp2 to ensure statx is whitelisted.
-  #travis_start "upgrade_libseccomp2"
-  #sudo apt-get update && sudo apt-get install -y libseccomp2
-  #travis_end
   travis_start "docker_pull"
   docker pull ${DOCKER_IMAGE}
   travis_end


### PR DESCRIPTION
This reverts #169, which was a temporary measure until Foundation could fall back to `lstat` when `statx` was present but not permitted.

apple/swift-corelibs-foundation#2388 is now merged and in the latest `5.1-DEVELOPMENT-SNAPSHOT-2019-07-09-a`, so we should be able to remove this workaround.
